### PR TITLE
Work around `where <T>` parser restriction

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -282,6 +282,13 @@ fn transform_block(context: Context, sig: &MethodSig, block: &mut Block) {
         _ => {}
     }
 
+    if let Some(where_clause) = &mut standalone.decl.generics.where_clause {
+        // Work around an input bound like `where Self::Output: Send` expanding
+        // to `where <AsyncTrait>::Output: Send` which is illegal syntax because
+        // `where<T>` is reserved for future use... :(
+        where_clause.predicates.insert(0, parse_quote!((): Sized));
+    }
+
     let mut replace = match context {
         Context::Trait { .. } => ReplaceReceiver::with(parse_quote!(AsyncTrait)),
         Context::Impl { receiver, as_trait } => {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,6 +2,9 @@
 
 use async_trait::async_trait;
 
+// Renaming to avoid masking missing absolute paths in generated code.
+use std::future::Future as StdFuture;
+
 #[async_trait]
 trait Trait {
     type Assoc;
@@ -114,4 +117,17 @@ pub async fn test_object_safe_with_default() {
 
     let object = &Struct as &dyn ObjectSafe;
     object.f().await;
+}
+
+// https://github.com/dtolnay/async-trait/issues/2
+#[async_trait]
+pub trait Issue2: StdFuture {
+    async fn flatten(self) -> <<Self as StdFuture>::Output as StdFuture>::Output
+    where
+        Self::Output: StdFuture + Send,
+        Self: Sized,
+    {
+        let nested_future = self.await;
+        nested_future.await
+    }
 }


### PR DESCRIPTION
Fixes #2.