### PR TITLE
Remove async_await feature gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ in a trait produces the following error:
 [rust-lang/rust#62149]: https://github.com/rust-lang/rust/issues/62149
 
 ```rust
-#![feature(async_await)]
-
 trait MyTrait {
     async fn f() {}
 }
@@ -41,8 +39,6 @@ The only thing to notice here is that we write an `#[async_trait]` macro on top
 of traits and trait impls that contain async fn, and then they work.
 
 ```rust
-#![feature(async_await)]
-
 use async_trait::async_trait;
 
 #[async_trait]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,6 @@
 //! [rust-lang/rust#62149]: https://github.com/rust-lang/rust/issues/62149
 //!
 //! ```compile_fail
-//! #![feature(async_await)]
-//!
 //! trait MyTrait {
 //!     async fn f() {}
 //! }
@@ -36,8 +34,6 @@
 //! top of traits and trait impls that contain async fn, and then they work.
 //!
 //! ```
-//! #![feature(async_await)]
-//!
 //! use async_trait::async_trait;
 //!
 //! #[async_trait]
@@ -156,8 +152,6 @@
 //! error message.
 //!
 //! ```compile_fail
-//! # #![feature(async_await)]
-//! #
 //! # use async_trait::async_trait;
 //! #
 //! type Elided<'a> = &'a usize;
@@ -179,8 +173,6 @@
 //! The fix is to name the lifetime or use `'_`.
 //!
 //! ```
-//! # #![feature(async_await)]
-//! #
 //! # use async_trait::async_trait;
 //! #
 //! # type Elided<'a> = &'a usize;
@@ -206,8 +198,6 @@
 //! by value, no associated types, etc.
 //!
 //! ```
-//! # #![feature(async_await)]
-//! #
 //! # use async_trait::async_trait;
 //! #
 //! #[async_trait]
@@ -262,8 +252,6 @@
 //! the default implementations are applicable to them:
 //!
 //! ```
-//! # #![feature(async_await)]
-//! #
 //! # use async_trait::async_trait;
 //! #
 //! #[async_trait]
@@ -285,8 +273,6 @@
 //! bounding them with `Self: Sized`:
 //!
 //! ```
-//! # #![feature(async_await)]
-//! #
 //! # use async_trait::async_trait;
 //! #
 //! #[async_trait]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,3 @@
-#![feature(async_await)]
-
 use async_trait::async_trait;
 
 #[async_trait]


### PR DESCRIPTION
`async_await` is stabilized in rust-lang/rust#63209