### PR TITLE
Pin Travis to nightly-2019-10-01

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: rust
 
 matrix:
   include:
-    - rust: nightly
+      # Pinned due to a bug in nightly:
+      # https://github.com/rust-lang/rust/issues/64964
+    - rust: nightly-2019-10-01
       script: cargo test
       env: RUSTFLAGS='--cfg async_trait_nightly_testing'
     - rust: stable


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/64964 is breaking our tests.

```console
error: internal compiler error: src/librustc/ich/impls_ty.rs:100: StableHasher: unexpected region '_#0r

thread 'rustc' panicked at 'Box<Any>', src/librustc_errors/lib.rs:912:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports

note: rustc 1.40.0-nightly (702b45e40 2019-10-01) running on x86_64-unknown-linux-gnu

note: compiler flags: -C debuginfo=2 -C incremental

note: some of the compiler flags provided by cargo are hidden
```