### PR TITLE
fix: Always refer to the core crate

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -194,7 +194,7 @@ fn transform_sig(
             where_clause.predicates.push(if assume_bound || is_local {
                 parse_quote!(Self: #lifetime)
             } else {
-                parse_quote!(Self: core::marker::#bound + #lifetime)
+                parse_quote!(Self: ::core::marker::#bound + #lifetime)
             });
         }
     } else {
@@ -222,12 +222,12 @@ fn transform_sig(
     let bounds = if is_local {
         quote!(#lifetime)
     } else {
-        quote!(core::marker::Send + #lifetime)
+        quote!(::core::marker::Send + #lifetime)
     };
 
     sig.output = parse_quote! {
-        -> core::pin::Pin<Box<
-            dyn core::future::Future<Output = #ret> + #bounds
+        -> ::core::pin::Pin<Box<
+            dyn ::core::future::Future<Output = #ret> + #bounds
         >>
     };
 }
@@ -317,8 +317,8 @@ fn transform_block(
             match context {
                 Context::Trait { .. } => {
                     self_bound = Some(match mutability {
-                        Some(_) => parse_quote!(core::marker::Send),
-                        None => parse_quote!(core::marker::Sync),
+                        Some(_) => parse_quote!(::core::marker::Send),
+                        None => parse_quote!(::core::marker::Sync),
                     });
                     *arg = parse_quote! {
                         #under_self: &#lifetime #mutability AsyncTrait
@@ -343,7 +343,7 @@ fn transform_block(
             let under_self = Ident::new("_self", self_token.span);
             match context {
                 Context::Trait { .. } => {
-                    self_bound = Some(parse_quote!(core::marker::Send));
+                    self_bound = Some(parse_quote!(::core::marker::Send));
                     *arg = parse_quote! {
                         #mutability #under_self: AsyncTrait
                     };

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,6 +4,9 @@ use async_trait::async_trait;
 
 pub mod executor;
 
+// Dummy module to check that the expansion refer to rust's core crate
+mod core {}
+
 #[async_trait]
 trait Trait {
     type Assoc;
@@ -361,15 +364,14 @@ pub mod issue31 {
     }
 }
 
+#[async_trait]
+pub unsafe trait UnsafeTrait {}
 
 #[async_trait]
-pub unsafe trait UnsafeTrait { }
+unsafe impl UnsafeTrait for () {}
 
 #[async_trait]
-unsafe impl UnsafeTrait for () { }
+pub(crate) unsafe trait UnsafeTraitPubCrate {}
 
 #[async_trait]
-pub(crate) unsafe trait UnsafeTraitPubCrate { }
-
-#[async_trait]
-unsafe trait UnsafeTraitPrivate { }
+unsafe trait UnsafeTraitPrivate {}


### PR DESCRIPTION
And not to a user defined module or import named `core`