### PR TITLE
Fix static methods defined in trait with `where Self: ...` specified

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-trait"
-version = "0.1.16"
+version = "0.1.17"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -1,6 +1,8 @@
 use crate::lifetime::{has_async_lifetime, CollectLifetimes};
 use crate::parse::Item;
-use crate::receiver::{has_self_in_block, has_self_in_sig, has_self_in_where_predicate, ReplaceReceiver};
+use crate::receiver::{
+    has_self_in_block, has_self_in_sig, has_self_in_where_predicate, ReplaceReceiver,
+};
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote, ToTokens};
 use std::mem;
@@ -282,7 +284,7 @@ fn transform_block(
         );
     }
 
-    let fn_generics = mem::replace(&mut standalone.generics, outer_generics.clone());
+    let fn_generics = mem::replace(&mut standalone.generics, outer_generics);
 
     standalone.generics.params.extend(fn_generics.params);
 

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -1,6 +1,6 @@
 use crate::lifetime::{has_async_lifetime, CollectLifetimes};
 use crate::parse::Item;
-use crate::receiver::{has_self_in_block, has_self_in_sig, has_self_in_predicate, ReplaceReceiver};
+use crate::receiver::{has_self_in_block, has_self_in_sig, has_self_in_where_predicate, ReplaceReceiver};
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote, ToTokens};
 use std::mem;
@@ -275,7 +275,7 @@ fn transform_block(
              }| WhereClause {
                 predicates: predicates
                     .into_iter()
-                    .filter(|predicate| !has_self_in_predicate(&mut predicate.clone()))
+                    .filter(|predicate| !has_self_in_where_predicate(&mut predicate.clone()))
                     .collect(),
                 where_token,
             },

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -224,8 +224,8 @@ fn transform_sig(
 // Returns true if provided `WherePredicate` is bound on Self.
 //
 fn is_self_bound_predicate(predicate: &WherePredicate) -> bool {
-    if let WherePredicate::Type(where_predicate) = predicate {
-        if let syn::Type::Path(path) = &where_predicate.bounded_ty {
+    if let WherePredicate::Type(predicate_type) = predicate {
+        if let Type::Path(path) = &predicate_type.bounded_ty {
             return path
                 .path
                 .segments

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -420,19 +420,19 @@ fn transform_block(
     replace.visit_block_mut(block);
 
     let brace = block.brace_token;
-    *block = if !types.is_empty() {
-        parse_quote!({
-            #[allow(clippy::used_underscore_binding)]
-            #standalone #block
-            Box::pin(#inner::<#(#types),*>(#(#args),*))
-        })
+
+    let types_specifier = if !types.is_empty() {
+        quote! { ::<#(#types),*> }
     } else {
-        parse_quote!({
-            #[allow(clippy::used_underscore_binding)]
-            #standalone #block
-            Box::pin(#inner(#(#args),*))
-        })
+        quote! {}
     };
+
+    *block = parse_quote!({
+        #[allow(clippy::used_underscore_binding)]
+        #standalone #block
+        Box::pin(#inner#types_specifier(#(#args),*))
+    });
+
     block.brace_token = brace;
 }
 

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -2,7 +2,10 @@ use proc_macro2::{Group, TokenStream, TokenTree};
 use std::mem;
 use syn::punctuated::Punctuated;
 use syn::visit_mut::{self, VisitMut};
-use syn::{Block, ExprPath, Ident, Item, Macro, Path, QSelf, Receiver, Signature, Type, TypePath, WherePredicate};
+use syn::{
+    Block, ExprPath, Ident, Item, Macro, Path, QSelf, Receiver, Signature, Type, TypePath,
+    WherePredicate,
+};
 
 pub fn has_self_in_sig(sig: &mut Signature) -> bool {
     let mut visitor = HasSelf(false);

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -2,11 +2,17 @@ use proc_macro2::{Group, TokenStream, TokenTree};
 use std::mem;
 use syn::punctuated::Punctuated;
 use syn::visit_mut::{self, VisitMut};
-use syn::{Block, ExprPath, Ident, Item, Macro, Path, QSelf, Receiver, Signature, Type, TypePath};
+use syn::{Block, ExprPath, Ident, Item, Macro, Path, QSelf, Receiver, Signature, Type, TypePath, WherePredicate};
 
 pub fn has_self_in_sig(sig: &mut Signature) -> bool {
     let mut visitor = HasSelf(false);
     visitor.visit_signature_mut(sig);
+    visitor.0
+}
+
+pub fn has_self_in_predicate(sig: &mut WherePredicate) -> bool {
+    let mut visitor = HasSelf(false);
+    visitor.visit_where_predicate_mut(sig);
     visitor.0
 }
 

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -10,9 +10,9 @@ pub fn has_self_in_sig(sig: &mut Signature) -> bool {
     visitor.0
 }
 
-pub fn has_self_in_predicate(sig: &mut WherePredicate) -> bool {
+pub fn has_self_in_where_predicate(where_predicate: &mut WherePredicate) -> bool {
     let mut visitor = HasSelf(false);
-    visitor.visit_where_predicate_mut(sig);
+    visitor.visit_where_predicate_mut(where_predicate);
     visitor.0
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -140,7 +140,8 @@ pub async fn test_static_method_with_where_self_clause_in_trait() {
     #[async_trait]
     trait StaticWithWhereSelf
     where
-        Box<Self>: Sized, Self: Sized + Send,
+        Box<Self>: Sized,
+        Self: Sized + Send,
     {
         async fn get_one() -> u8 {
             1

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -136,6 +136,24 @@ pub async fn test_object_no_send() {
     object.f().await;
 }
 
+pub async fn test_static_method_with_where_self_clause_in_trait() {
+    #[async_trait]
+    trait StaticWithWhereSelf
+    where
+        Self: Sized + Send,
+    {
+        async fn get_one() -> u8 {
+            1
+        }
+    }
+
+    struct T {};
+
+    impl StaticWithWhereSelf for T {};
+
+    assert_eq!(T::get_one().await, 1);
+}
+
 #[async_trait]
 pub unsafe trait UnsafeTrait {}
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -140,7 +140,7 @@ pub async fn test_static_method_with_where_self_clause_in_trait() {
     #[async_trait]
     trait StaticWithWhereSelf
     where
-        Self: Sized + Send,
+        Box<Self>: Sized, Self: Sized + Send,
     {
         async fn get_one() -> u8 {
             1


### PR DESCRIPTION
Allows to define static methods on trait with `where Self: ...` specified. Example:
```rust
use async_trait::async_trait;

#[async_trait]
trait GetFive where Self: Sized {
    async fn get_five() -> u8 {
        5
    }
}

struct Empty {}

impl GetFive for Empty {}

#[tokio::main]
async fn main() {
    assert_eq!(Empty::get_five().await, 5);
}
```

Current behaviour: 
```
error[E0412]: cannot find type `AsyncTrait` in this scope
 --> src/main.rs:5:1
  |
5 | #[async_trait]
  | ^^^^^^^^^^^^^^ not found in this scope

error: aborting due to previous error

For more information about this error, try `rustc --explain E0412`.
``` 