### PR TITLE
add support for const generics

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -405,6 +405,13 @@ fn transform_block(
     replace.visit_signature_mut(&mut standalone);
     replace.visit_block_mut(block);
 
+    let mut generics = types;
+    let consts = standalone
+        .generics
+        .const_params()
+        .map(|param| param.ident.clone());
+    generics.extend(consts);
+
     let brace = block.brace_token;
     let box_pin = quote_spanned!(brace.span=> {
         #[allow(
@@ -412,7 +419,7 @@ fn transform_block(
             clippy::used_underscore_binding,
         )]
         #standalone #block
-        Box::pin(#inner::<#(#types),*>(#(#args),*))
+        Box::pin(#inner::<#(#generics),*>(#(#args),*))
     });
     *block = parse_quote!(#box_pin);
     block.brace_token = brace;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(async_trait_nightly_testing, feature(specialization))]
+#![cfg_attr(async_trait_nightly_testing, feature(specialization, const_generics))]
 
 use async_trait::async_trait;
 
@@ -30,6 +30,9 @@ trait Trait {
     async fn generic_type_param<T: Send>(x: Box<T>) -> T {
         *x
     }
+
+    #[cfg(async_trait_nightly_testing)]
+    async fn generic_const<const C: usize>(_: [u8; C]) {}
 
     async fn calls(&self) {
         self.selfref().await;
@@ -64,6 +67,9 @@ impl Trait for Struct {
         *x
     }
 
+    #[cfg(async_trait_nightly_testing)]
+    async fn generic_const<const C: usize>(_: [u8; C]) {}
+
     async fn calls(&self) {
         self.selfref().await;
         Self::elided_lifetime("").await;
@@ -85,6 +91,8 @@ pub async fn test() {
     Struct::elided_lifetime("").await;
     Struct::explicit_lifetime("").await;
     Struct::generic_type_param(Box::new("")).await;
+    #[cfg(async_trait_nightly_testing)]
+    Struct::generic_const([0; 10]).await;
 
     let mut s = Struct;
     s.calls().await;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -32,7 +32,7 @@ trait Trait {
     }
 
     #[cfg(async_trait_nightly_testing)]
-    async fn generic_const<const C: usize>(_: [u8; C]) {}
+    async fn generic_const<T: Copy + Send, const C: usize>(a: [T; C]) -> T {a[0]}
 
     async fn calls(&self) {
         self.selfref().await;
@@ -68,7 +68,7 @@ impl Trait for Struct {
     }
 
     #[cfg(async_trait_nightly_testing)]
-    async fn generic_const<const C: usize>(_: [u8; C]) {}
+    async fn generic_const<T: Copy + Send, const C: usize>(a: [T; C]) -> T {a[0]}
 
     async fn calls(&self) {
         self.selfref().await;


### PR DESCRIPTION
async-trait currently doesnt work with const generics. this pull request tries to fix this

closes #57