### PR TITLE
Suppress clippy::type_repetition_in_bounds

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -416,6 +416,7 @@ fn transform_block(
     let box_pin = quote_spanned!(brace.span=> {
         #[allow(
             clippy::missing_docs_in_private_items,
+            clippy::type_repetition_in_bounds,
             clippy::used_underscore_binding,
         )]
         #standalone #block


### PR DESCRIPTION
Similarly to #21 and #51 suppresses yet another `clippy::pedantic` complaining lint:

```
error: this type has already been used as a bound predicate
  --> crates/my-crate/src/conn.rs:15:1
   |
15 | #[async_trait(?Send)]
   | ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `-D clippy::type-repetition-in-bounds` implied by `-D clippy::pedantic`
   = help: consider combining the bounds: `T: ToStatement`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_repetition_in_bounds

```