### PR TITLE
Preserve span of Self keyword

### DIFF
--- a/tests/ui/self-span.rs
+++ b/tests/ui/self-span.rs
@@ -1,0 +1,18 @@
+use async_trait::async_trait;
+
+pub struct Struct {}
+
+#[async_trait]
+pub trait Trait {
+    async fn method(self);
+}
+
+#[async_trait]
+impl Trait for Struct {
+    async fn method(self) {
+        let _: () = self;
+        let _: Self = Self;
+    }
+}
+
+fn main() {}

--- a/tests/ui/self-span.stderr
+++ b/tests/ui/self-span.stderr
@@ -1,0 +1,28 @@
+error[E0423]: expected value, found struct `Struct`
+  --> $DIR/self-span.rs:14:23
+   |
+3  | pub struct Struct {}
+   | -------------------- `Struct` defined here
+...
+14 |         let _: Self = Self;
+   |                       ^^^^ did you mean `Struct { /* fields */ }`?
+   |
+help: consider importing one of these items instead
+   |
+1  | use syn::Data::Struct;
+   |
+1  | use syn::Expr::Struct;
+   |
+1  | use syn::Item::Struct;
+   |
+1  | use syn::Pat::Struct;
+   |
+     and 1 other candidate
+
+error[E0308]: mismatched types
+  --> $DIR/self-span.rs:13:21
+   |
+13 |         let _: () = self;
+   |                --   ^^^^ expected `()`, found struct `Struct`
+   |                |
+   |                expected due to this


### PR DESCRIPTION
The following code:

```rust
use async_trait::async_trait;

pub struct Struct {}

#[async_trait]
pub trait Trait {
    async fn method(self);
}

#[async_trait]
impl Trait for Struct {
    async fn method(self) {
        let _: Self = Self;
    }
}
```

The error message points to wrong span:

```text
error[E0423]: expected value, found struct `Struct`
  --> src/lib.rs:11:16
   |
11 | impl Trait for Struct {
   |                ^^^^^^ did you mean `(Struct { /* fields */ })`?
   |
```

This PR fixes span of Self keyword to make the error message to point to the correct span:

```text
error[E0423]: expected value, found struct `Struct`
  --> $DIR/self-span.rs:14:23
   |
3  | pub struct Struct {}
   | -------------------- `Struct` defined here
...
14 |         let _: Self = Self;
   |                       ^^^^ did you mean `Struct { /* fields */ }`?
   |
```