### PR TITLE
Propagate the span of Self keyword to QSelf

### DIFF
--- a/tests/ui/self-span.rs
+++ b/tests/ui/self-span.rs
@@ -2,6 +2,10 @@ use async_trait::async_trait;
 
 pub struct S {}
 
+pub enum E {
+    V {}
+}
+
 #[async_trait]
 pub trait Trait {
     async fn method(self);
@@ -12,6 +16,14 @@ impl Trait for S {
     async fn method(self) {
         let _: () = self;
         let _: Self = Self;
+    }
+}
+
+#[async_trait]
+impl Trait for E {
+    async fn method(self) {
+        let _: () = self;
+        let _: Self = Self::V;
     }
 }
 

--- a/tests/ui/self-span.stderr
+++ b/tests/ui/self-span.stderr
@@ -1,16 +1,30 @@
 error[E0423]: expected value, found struct `S`
-  --> $DIR/self-span.rs:14:23
+  --> $DIR/self-span.rs:18:23
    |
 3  | pub struct S {}
    | --------------- `S` defined here
 ...
-14 |         let _: Self = Self;
+18 |         let _: Self = Self;
    |                       ^^^^ did you mean `S { /* fields */ }`?
 
 error[E0308]: mismatched types
-  --> $DIR/self-span.rs:13:21
+  --> $DIR/self-span.rs:17:21
    |
-13 |         let _: () = self;
+17 |         let _: () = self;
    |                --   ^^^^ expected `()`, found struct `S`
    |                |
    |                expected due to this
+
+error[E0308]: mismatched types
+  --> $DIR/self-span.rs:25:21
+   |
+25 |         let _: () = self;
+   |                --   ^^^^ expected `()`, found enum `E`
+   |                |
+   |                expected due to this
+
+error[E0533]: expected unit struct, unit variant or constant, found struct variant `Self::V`
+  --> $DIR/self-span.rs:26:23
+   |
+26 |         let _: Self = Self::V;
+   |                       ^^^^^^^


### PR DESCRIPTION
A similar case to #102.

The following code:

```rust
pub enum E {
    V {}
}

#[async_trait]
impl Trait for E {
    async fn method(self) {
        let _: () = self;
        let _: Self = Self::V;
    }
}
```

The error message points to call-site span:

```text
error[E0533]: expected unit struct, unit variant or constant, found struct variant `#[async_trait]`
  --> $DIR/self-span.rs:22:1
   |
22 | #[async_trait]
   | ^^^^^^^^^^^^^^
   |
```

This PR fixes span of `<` and `>` tokens of `QSelf` to make the error message to point to the correct span:

```text
error[E0533]: expected unit struct, unit variant or constant, found struct variant `Self::V`
  --> $DIR/self-span.rs:26:23
   |
26 |         let _: Self = Self::V;
   |                       ^^^^^^^
```

(this originally caught in https://github.com/taiki-e/pin-project/pull/249. also https://github.com/serde-rs/serde/pull/1830 is already updated to include this)