### PR TITLE
Replace elided lifetimes to explicit lifetimes in trait impl

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -81,6 +81,13 @@ pub fn expand(input: &mut Item, is_local: bool) {
             }
         }
         Item::Impl(input) => {
+            let mut lifetimes = CollectLifetimes::with("'impl_life");
+            lifetimes.visit_type_mut(&mut *input.self_ty);
+            lifetimes.visit_path_mut(&mut input.trait_.as_mut().unwrap().1);
+            let params = &input.generics.params;
+            let elided = lifetimes.elided;
+            input.generics.params = parse_quote!( #(#elided,)* #params );
+
             let context = Context::Impl {
                 impl_generics: &input.generics,
                 receiver: &input.self_ty,

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -24,6 +24,7 @@ impl VisitMut for HasAsyncLifetime {
 pub struct CollectLifetimes {
     pub elided: Vec<Lifetime>,
     pub explicit: Vec<Lifetime>,
+    pub name: &'static str,
 }
 
 impl CollectLifetimes {
@@ -31,6 +32,15 @@ impl CollectLifetimes {
         CollectLifetimes {
             elided: Vec::new(),
             explicit: Vec::new(),
+            name: "'life",
+        }
+    }
+
+    pub fn with(name: &'static str) -> Self {
+        CollectLifetimes {
+            elided: Vec::new(),
+            explicit: Vec::new(),
+            name,
         }
     }
 
@@ -50,7 +60,7 @@ impl CollectLifetimes {
     }
 
     fn next_lifetime(&mut self) -> Lifetime {
-        let name = format!("'life{}", self.elided.len());
+        let name = format!("{}{}", self.name, self.elided.len());
         let life = Lifetime::new(&name, Span::call_site());
         self.elided.push(life.clone());
         life


### PR DESCRIPTION
Fixes #106

Currently, these are only applying for function arguments, but this PR change this to also apply to trait and implementor's paths.

```rust
impl Trait<'_> for &Type<'_> {}

// converted to:
impl<'impl_life0, 'impl_life1, 'impl_life2> 
    Trait<'impl_life0> for &'impl_life1 Type<'impl_life2> {}
```