### PR TITLE
Update async lifetime in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,18 +103,18 @@ can't be that badly broken.
 ## Explanation
 
 Async fns get transformed into methods that return `Pin<Box<dyn Future + Send +
-'async>>` and delegate to a private async freestanding function.
+'async_trait>>` and delegate to a private async freestanding function.
 
 For example the `impl Advertisement for AutoplayingVideo` above would be
 expanded as:
 
 ```rust
 impl Advertisement for AutoplayingVideo {
-    fn run<'async>(
-        &'async self,
-    ) -> Pin<Box<dyn std::future::Future<Output = ()> + Send + 'async>>
+    fn run<'async_trait>(
+        &'async_trait self,
+    ) -> Pin<Box<dyn std::future::Future<Output = ()> + Send + 'async_trait>>
     where
-        Self: Sync + 'async,
+        Self: Sync + 'async_trait,
     {
         async fn run(_self: &AutoplayingVideo) {
             /* the original method body */


### PR DESCRIPTION
Update the lifetimes in the example to be `'async_trait`, rather than `'async`. This brings the example into sync with `transform_sig()`.