### PR TITLE
Work around unused_parens rustc issue

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -446,6 +446,7 @@ fn transform_block(
     let box_pin = quote_spanned!(brace.span=> {
         #[allow(
             #allow_non_snake_case
+            unused_parens, // https://github.com/dtolnay/async-trait/issues/118
             clippy::missing_docs_in_private_items,
             clippy::needless_lifetimes,
             clippy::ptr_arg,


### PR DESCRIPTION
Closes #118.

Rustc is inserting needless parens into the macro input before calling async_trait, then warning the user that they wrote needless parens. See https://github.com/dtolnay/async-trait/issues/118#issuecomment-673083481.