### PR TITLE
Optional sync futures, async block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-trait"
-version = "0.1.40"
+version = "0.1.41"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,12 @@ readme = "README.md"
 
 [lib]
 proc-macro = true
+path = "src/lib.rs"
 
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full", "visit-mut"] }
+syn = { version = "1.0", features = ["full", "visit-mut", "extra-traits"] }
 
 [dev-dependencies]
 rustversion = "1.0"

--- a/README.tpl
+++ b/README.tpl
@@ -1,0 +1,20 @@
+# Type erasure for async trait methods - {{crate}} {{version}}
+
+{{readme}}
+
+<br>
+
+## License - {{license}}
+
+<sup>
+Licensed under either of <a href="LICENSE-APACHE">Apache License, Version
+2.0</a> or <a href="LICENSE-MIT">MIT license</a> at your option.
+</sup>
+
+<br>
+
+<sub>
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this crate by you, as defined in the Apache-2.0 license, shall
+be dual licensed as above, without any additional terms or conditions.
+</sub>

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -314,10 +314,10 @@ fn transform_sig(
 //     }
 //
 // Output:
-//     async fn f<T, AsyncTrait>(_self: &AsyncTrait, x: &T) -> Ret {
-//         _self + x
-//     }
-//     Box::pin(async_trait_method::<T, Self>(self, x))
+//     let fut = async move {
+//         self + x
+//     };
+//     Box::new(fut)
 fn transform_block(block: &mut Block) {
     if let Some(Stmt::Item(syn::Item::Verbatim(item))) = block.stmts.first() {
         if block.stmts.len() == 1 && item.to_string() == ";" {

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -71,9 +71,15 @@ pub fn expand(input: &mut Item, is_local: bool) {
                         let future_bounds = get_future_bounds(&mut method.attrs);
                         transform_sig(context, sig, has_self, has_default, is_local, future_bounds);
                         method.attrs.push(parse_quote!(#[must_use]));
-                        method.attrs.push(parse_quote!(#[allow(clippy::needless_lifetimes)]));
-                        method.attrs.push(parse_quote!(#[allow(clippy::extra_unused_lifetimes)]));
-                        method.attrs.push(parse_quote!(#[allow(clippy::type_repetition_in_bounds)]));
+                        method
+                            .attrs
+                            .push(parse_quote!(#[allow(clippy::needless_lifetimes)]));
+                        method
+                            .attrs
+                            .push(parse_quote!(#[allow(clippy::extra_unused_lifetimes)]));
+                        method
+                            .attrs
+                            .push(parse_quote!(#[allow(clippy::type_repetition_in_bounds)]));
                     }
                 }
             }
@@ -104,20 +110,16 @@ pub fn expand(input: &mut Item, is_local: bool) {
         }
     }
 }
-
 fn get_future_bounds(attrs: &mut Vec<Attribute>) -> FutureBounds {
-    let model: Attribute = parse_quote!(#[future_is(Sync)]);
+    let model: Attribute = parse_quote!(#[future_is[Sync]]);
     let mut result = FutureBounds::new();
     for pos in (0..attrs.len()).rev() {
         let attr = &attrs[pos];
-        if attr.path == model.path
-            && attr.pound_token == model.pound_token
-            && attr.style == model.style
-        {
+        if attr.path == model.path && attr.style == model.style {
             let future_is = attrs.remove(pos);
             let remaining: TokenStream = result.parse(future_is).into();
             if !remaining.is_empty() {
-                attrs.insert(pos, parse_quote!(#[::async_trait::error(#remaining)]))
+                attrs.insert(pos, parse_quote!(#[::async_trait::future_is(#remaining)]))
             }
         }
     }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -71,6 +71,9 @@ pub fn expand(input: &mut Item, is_local: bool) {
                         let future_bounds = get_future_bounds(&mut method.attrs);
                         transform_sig(context, sig, has_self, has_default, is_local, future_bounds);
                         method.attrs.push(parse_quote!(#[must_use]));
+                        method.attrs.push(parse_quote!(#[allow(clippy::needless_lifetimes)]));
+                        method.attrs.push(parse_quote!(#[allow(clippy::extra_unused_lifetimes)]));
+                        method.attrs.push(parse_quote!(#[allow(clippy::type_repetition_in_bounds)]));
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,14 +162,14 @@
 //! Fortunately the compiler is able to diagnose missing lifetimes with a good
 //! error message.
 //!
-//! ```compile_fail
+//! ```
 //! # use async_trait::async_trait;
 //! #
 //! type Elided<'a> = &'a usize;
 //!
 //! #[async_trait]
 //! trait Test {
-//!     async fn test(not_okay: Elided, okay: &usize) {}
+//!     async fn test(also_okay: Elided, okay: &usize) {}
 //! }
 //! ```
 //!
@@ -325,4 +325,12 @@ pub fn async_trait(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut item = parse_macro_input!(input as Item);
     expand(&mut item, args.local);
     TokenStream::from(quote!(#item))
+}
+
+/// Serves to replace future_is attribute with a parsing error 
+/// since future_is doesnt really exist outside of the scope of 
+/// async_trait
+#[proc_macro_attribute]
+pub fn error(attr: TokenStream, _item: TokenStream) -> TokenStream {
+    attr
 }

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -1,13 +1,6 @@
 use proc_macro2::Span;
 use syn::visit_mut::{self, VisitMut};
-use syn::{Block, GenericArgument, Item, Lifetime, Receiver, Signature, TypeReference};
-
-pub fn has_async_lifetime(sig: &mut Signature, block: &mut Block) -> bool {
-    let mut visitor = HasAsyncLifetime(false);
-    visitor.visit_signature_mut(sig);
-    visitor.visit_block_mut(block);
-    visitor.0
-}
+use syn::{GenericArgument, Item, Lifetime, Receiver, TypeReference};
 
 struct HasAsyncLifetime(bool);
 

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -8,18 +8,11 @@ use syn::visit_mut::{self, VisitMut};
 use syn::{
     parse_quote, Block, Error, ExprPath, ExprStruct, Ident, Item, Macro, PatPath, PatStruct,
     PatTupleStruct, Path, PathArguments, QSelf, Receiver, Signature, Token, Type, TypePath,
-    WherePredicate,
 };
 
 pub fn has_self_in_sig(sig: &mut Signature) -> bool {
     let mut visitor = HasSelf(false);
     visitor.visit_signature_mut(sig);
-    visitor.0
-}
-
-pub fn has_self_in_where_predicate(where_predicate: &mut WherePredicate) -> bool {
-    let mut visitor = HasSelf(false);
-    visitor.visit_where_predicate_mut(where_predicate);
     visitor.0
 }
 
@@ -76,20 +69,6 @@ pub struct ReplaceReceiver {
 }
 
 impl ReplaceReceiver {
-    pub fn with(ty: Type) -> Self {
-        ReplaceReceiver {
-            with: ty,
-            as_trait: None,
-        }
-    }
-
-    pub fn with_as_trait(ty: Type, as_trait: Path) -> Self {
-        ReplaceReceiver {
-            with: ty,
-            as_trait: Some(as_trait),
-        }
-    }
-
     fn self_ty(&self, span: Span) -> Type {
         respan(&self.with, span)
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1025,3 +1025,49 @@ pub mod issue123 {
     #[async_trait]
     impl<T> Trait<T> for () {}
 }
+
+// https://github.com/dtolnay/async-trait/issues/77
+pub mod issue77 {
+    use async_trait::async_trait;
+
+    pub fn is_sync<T: Sync>(_tester: T) {}
+    pub fn is_static<T: 'static>(_tester: T) {}
+
+    pub fn test_sync<T: SyncFuture>(tested: T) {
+        is_sync(tested.f())
+    }
+
+    #[async_trait]
+    pub trait SyncFuture {
+        #[future_is(Sync)]
+        async fn f(&self) -> &str;
+    }
+
+    #[async_trait]
+    impl SyncFuture for () {
+        #[future_is(Sync)]
+        async fn f(&self) -> &str {
+            "hola"
+        }
+    }
+
+    /* Not working yet, doesn't like '
+    fn test_static<T: StaticFuture>(tested: T) {
+        is_static(tested.f())
+    }
+
+    #[async_trait]
+    pub trait StaticFuture {
+        #[future_is('static)]
+        async fn f(&self) -> &str;
+    }
+    
+    #[async_trait]
+    impl StaticFuture for () {
+        #[future_is('static)]
+        async fn f(&self) -> &str {
+            "hola"
+        }
+    }
+    */
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1089,11 +1089,11 @@ pub mod issue77 {
 
     #[async_trait]
     trait Test {
-        async fn test(also_okay: Elided, okay: &usize);
+        async fn test(_also_okay: Elided, _okay: &usize);
     }
 
     #[async_trait]
     impl Test for () {
-        async fn test(also_okay: Elided, okay: &usize) {}
+        async fn test(_also_okay: Elided, _okay: &usize) {}
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1042,7 +1042,7 @@ pub mod issue77 {
     pub fn test_static_owned<T: StaticFuture + 'static>(tested: T) {
         is_static(tested.test_owned())
     }
-    pub fn test_sily<T: SilyFuture>(tested: T) {
+    pub fn test_sily<T: SillyFuture>(tested: T) {
         is_sync(tested.f())
     }
 
@@ -1053,9 +1053,9 @@ pub mod issue77 {
     }
 
     #[async_trait]
-    pub trait SilyFuture {
+    pub trait SillyFuture {
         #[future_is[Sync]]
-        #[future_is[Send+'static]]
+        #[future_is[Send + 'static]]
         async fn f(&self) -> &str;
     }
 

--- a/tests/ui/elided-new.rs
+++ b/tests/ui/elided-new.rs
@@ -1,0 +1,27 @@
+#![deny(bare_trait_objects)]
+
+use async_trait::async_trait;
+
+type Elided<'a> = &'a usize;
+
+#[async_trait]
+trait TestOk1 {
+    async fn test_ok1(elided: Elided, okay: &usize);
+}
+
+#[async_trait]
+trait TestOk2 {
+    async fn test_ok2<'a>(elided: Elided<'a>, okay: &usize) -> &'a usize;
+}
+
+#[async_trait]
+trait TestOk3 {
+    async fn test_ok3(elided: Elided) -> &usize;
+}
+
+#[async_trait]
+trait TestNok {
+    async fn test_nok(elided: Elided, okay: &usize) -> &usize;
+}
+
+fn main() {}

--- a/tests/ui/elided-new.stderr
+++ b/tests/ui/elided-new.stderr
@@ -1,0 +1,12 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/elided-new.rs:24:56
+   |
+24 |     async fn test_nok(elided: Elided, okay: &usize) -> &usize;
+   |                               ------        ------     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+note: these named lifetimes are available to use
+  --> $DIR/elided-new.rs:22:1
+   |
+22 | #[async_trait]
+   | ^^^^^^^^^^^^^^

--- a/tests/ui/future-is-nonsense.rs
+++ b/tests/ui/future-is-nonsense.rs
@@ -1,0 +1,15 @@
+use async_trait::async_trait;
+
+#[async_trait]
+trait Trait {
+    #[future_is[Nonsense]]
+    async fn method1(&mut self);
+
+    #[future_is[Sync - Send]]
+    async fn method2(&mut self);
+    
+    #[future_is(Sync)]
+    async fn method2(&mut self);
+}
+
+fn main() {}

--- a/tests/ui/future-is-nonsense.rs
+++ b/tests/ui/future-is-nonsense.rs
@@ -9,7 +9,7 @@ trait Trait {
     async fn method2(&mut self);
     
     #[future_is(Sync)]
-    async fn method2(&mut self);
+    async fn method3(&mut self);
 }
 
 fn main() {}

--- a/tests/ui/future-is-nonsense.stderr
+++ b/tests/ui/future-is-nonsense.stderr
@@ -1,0 +1,19 @@
+error: expected `+`
+ --> $DIR/future-is-nonsense.rs:8:22
+  |
+8 |     #[future_is[Sync - Send]]
+  |                      ^
+
+error: expected square brackets
+  --> $DIR/future-is-nonsense.rs:11:16
+   |
+11 |     #[future_is(Sync)]
+   |                ^
+
+error[E0405]: cannot find trait `Nonsense` in this scope
+ --> $DIR/future-is-nonsense.rs:5:17
+  |
+4 | trait Trait {
+  |            - help: you might be missing a type parameter: `<Nonsense>`
+5 |     #[future_is[Nonsense]]
+  |                 ^^^^^^^^ not found in this scope

--- a/tests/ui/self-span.stderr
+++ b/tests/ui/self-span.stderr
@@ -1,12 +1,3 @@
-error[E0423]: expected value, found struct `S`
-  --> $DIR/self-span.rs:18:23
-   |
-3  | pub struct S {}
-   | --------------- `S` defined here
-...
-18 |         let _: Self = Self;
-   |                       ^^^^ help: use struct literal syntax instead: `S {}`
-
 error[E0308]: mismatched types
   --> $DIR/self-span.rs:17:21
    |
@@ -14,6 +5,12 @@ error[E0308]: mismatched types
    |                --   ^^^^ expected `()`, found struct `S`
    |                |
    |                expected due to this
+
+error: the `Self` constructor can only be used with tuple or unit structs
+  --> $DIR/self-span.rs:18:23
+   |
+18 |         let _: Self = Self;
+   |                       ^^^^ help: use curly brackets: `Self { /* fields */ }`
 
 error[E0308]: mismatched types
   --> $DIR/self-span.rs:25:21

--- a/tests/ui/send-not-implemented.stderr
+++ b/tests/ui/send-not-implemented.stderr
@@ -7,7 +7,7 @@ error: future cannot be sent between threads safely
 10 | |         let _guard = mutex.lock().unwrap();
 11 | |         f().await;
 12 | |     }
-   | |_____^ future returned by `__test` is not `Send`
+   | |_____^ future created by async block is not `Send`
    |
    = help: within `impl std::future::Future`, the trait `std::marker::Send` is not implemented for `std::sync::MutexGuard<'_, ()>`
 note: future is not `Send` as this value is used across an await

--- a/tests/ui/sync-future-impossible.rs
+++ b/tests/ui/sync-future-impossible.rs
@@ -1,0 +1,21 @@
+use async_trait::async_trait;
+
+#[async_trait]
+trait Trait {
+    #[future_is[Sync]]
+    async fn method(&mut self);
+}
+
+struct Struct<T> {
+    value: T,
+}
+
+#[async_trait]
+impl<T: std::fmt::Display + Send> Trait for Struct<T> {
+    #[future_is[Sync]]
+    async fn method(&mut self) {
+        println!("{}", self.value);
+    }
+}
+
+fn main() {}

--- a/tests/ui/sync-future-impossible.stderr
+++ b/tests/ui/sync-future-impossible.stderr
@@ -1,0 +1,19 @@
+error: future cannot be shared between threads safely
+  --> $DIR/sync-future-impossible.rs:16:32
+   |
+16 |       async fn method(&mut self) {
+   |  ________________________________^
+17 | |         println!("{}", self.value);
+18 | |     }
+   | |_____^ future created by async block is not `Sync`
+   |
+note: captured value is not `Sync`
+  --> $DIR/sync-future-impossible.rs:17:24
+   |
+17 |         println!("{}", self.value);
+   |                        ^^^^ has type `&mut Struct<T>` which is not `Sync`
+   = note: required for the cast to the object type `dyn std::future::Future<Output = ()> + std::marker::Send + std::marker::Sync`
+help: consider further restricting this bound
+   |
+14 | impl<T: std::fmt::Display + Send + std::marker::Sync> Trait for Struct<T> {
+   |                                  ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unsupported-self.stderr
+++ b/tests/ui/unsupported-self.stderr
@@ -1,4 +1,4 @@
-error: Self type of this impl is unsupported in expression position
+error: the `Self` constructor can only be used with tuple or unit structs
   --> $DIR/unsupported-self.rs:11:17
    |
 11 |         let _ = Self;


### PR DESCRIPTION
* This change adds a virtual `#[future_is[BOUNDS]]` attribute for async fns so you can opt in for Sync or 'static future
* Refactored to `async move` block instead of inner function as it removed a whole lot of complexity and enabled the 'static stuff
* closes #77