### PR TITLE
Suppress used_underscore_binding on wrapper function

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -72,6 +72,7 @@ pub fn expand(input: &mut Item, is_local: bool) {
                         if let Some(block) = block {
                             has_self |= has_self_in_block(block);
                             transform_block(context, sig, block, has_self, is_local);
+                            method.attrs.push(parse_quote!(#[allow(clippy::used_underscore_binding)]));
                         }
                         let has_default = method.default.is_some();
                         transform_sig(context, sig, has_self, has_default, is_local);
@@ -101,6 +102,7 @@ pub fn expand(input: &mut Item, is_local: bool) {
                         let has_self = has_self_in_sig(sig) || has_self_in_block(block);
                         transform_block(context, sig, block, has_self, is_local);
                         transform_sig(context, sig, has_self, false, is_local);
+                        method.attrs.push(parse_quote!(#[allow(clippy::used_underscore_binding)]));
                     }
                 }
             }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1025,3 +1025,26 @@ pub mod issue123 {
     #[async_trait]
     impl<T> Trait<T> for () {}
 }
+
+// https://github.com/dtolnay/async-trait/issues/129
+pub mod issue129 {
+    #![deny(clippy::pedantic)]
+
+    use async_trait::async_trait;
+
+    #[async_trait]
+    pub trait TestTrait {
+        async fn a(_b: u8, c: u8) -> u8 {
+            c
+        }
+    }
+
+    pub struct TestStruct;
+
+    #[async_trait]
+    impl TestTrait for TestStruct {
+        async fn a(_b: u8, c: u8) -> u8 {
+            c
+        }
+    }
+}


### PR DESCRIPTION
The wrapper future-returning function we generate simply forwards all arguments to the async inner function, so we expect it always uses all arguments, including ones that are named with an underscore.

Fixes #129.