### PR TITLE
Re-enable tracing attribute test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ syn = { version = "1.0.61", features = ["full", "visit-mut"] }
 rustversion = "1.0"
 tracing = "0.1.14"
 tracing-attributes = "0.1.14"
-tracing-futures = "0.2"
 trybuild = { version = "1.0.19", features = ["diff"] }
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ syn = { version = "1.0.61", features = ["full", "visit-mut"] }
 [dev-dependencies]
 rustversion = "1.0"
 tracing = "0.1.14"
-tracing-attributes = "0.1.8"
+tracing-attributes = "0.1.14"
 tracing-futures = "0.2"
 trybuild = { version = "1.0.19", features = ["diff"] }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -615,7 +615,6 @@ pub mod issue45 {
     }
 
     #[test]
-    #[should_panic]
     fn tracing() {
         // Create the future outside of the subscriber, as no call to tracing
         // should be made until the future is polled.


### PR DESCRIPTION
Fixed in the tracing crate by https://github.com/tokio-rs/tracing/pull/1291.