### PR TITLE
Allow fully elaborated `::core::marker::Trait` supertraits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0.61", features = ["full", "visit-mut"] }
+syn = { version = "1.0.61", features = ["full", "visit-mut", "extra-traits"] }
 
 [dev-dependencies]
 futures = "0.3"

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -396,7 +396,7 @@ fn positional_arg(i: usize, pat: &Pat) -> Ident {
 fn has_bound(supertraits: &Supertraits, marker: &Ident) -> bool {
     for bound in supertraits {
         if let TypeParamBound::Trait(bound) = bound {
-            if bound.path.is_ident(marker) {
+            if bound.path.is_ident(marker) || bound.path == parse_quote!(::core::marker::#marker) {
                 return true;
             }
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1363,3 +1363,16 @@ pub mod issue161 {
         }
     }
 }
+
+// https://github.com/dtolnay/async-trait/issues/169
+#[deny(where_clauses_object_safety)]
+pub mod issue169 {
+    use async_trait::async_trait;
+
+    #[async_trait]
+    pub trait Trait: ::core::marker::Sync {
+        async fn f(&self) {}
+    }
+
+    pub fn test(_t: &dyn Trait) {}
+}


### PR DESCRIPTION
1. Not sure if we want to use `Eq` on `syn::Path` or just break down the path's elements and compare idents ourselves.
2. Should I add cases for `::std::marker::Path`? The list kinda blows up, so I would say most explicit path and least explicit ident is okay for now.

Fixes #169