### PR TITLE
Feature min_type_alias_impl_trait renamed to type_alias_impl_trait

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(
     async_trait_nightly_testing,
-    feature(min_specialization, min_type_alias_impl_trait)
+    feature(min_specialization, type_alias_impl_trait)
 )]
 #![allow(
     clippy::let_underscore_drop,


### PR DESCRIPTION
As of nightly-2021-07-29:

```console
error[E0557]: feature has been removed
 --> tests/test.rs:3:33
  |
3 |     feature(min_specialization, min_type_alias_impl_trait)
  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ feature has been removed
  |
  = note: removed in favor of full type_alias_impl_trait

error[E0658]: `impl Trait` in type aliases is unstable
    --> tests/test.rs:1299:22
     |
1299 |         type Assoc = impl Sized;
     |                      ^^^^^^^^^^
     |
     = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
     = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
```