### PR TITLE
Add per-method #[async_trait(?Send)]

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -28,7 +28,11 @@ impl Parse for Item {
             item.attrs = attrs;
             Ok(Item::Impl(item))
         } else {
-            Err(lookahead.error())
+            Err(Error::new(
+                Span::call_site(),
+                format!("invalid item for #[async_trait]: {}.\nDid you forget #[async_trait] on the outer trait or impl block?",
+                        lookahead.error()),
+            ))
         }
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -149,6 +149,20 @@ pub async fn test_object_no_send() {
 }
 
 #[async_trait]
+pub trait NoSendMethod {
+    #[async_trait(?Send)]
+    async fn test_method_no_send();
+    async fn test_method_no_attrs();
+}
+
+#[async_trait]
+impl NoSendMethod for () {
+    #[async_trait(?Send)]
+    async fn test_method_no_send() {}
+    async fn test_method_no_attrs() {}
+}
+
+#[async_trait]
 pub unsafe trait UnsafeTrait {}
 
 #[async_trait]

--- a/tests/ui/attr-in-sync-method.rs
+++ b/tests/ui/attr-in-sync-method.rs
@@ -1,0 +1,9 @@
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait Trait {
+    #[async_trait(?Send)]
+    fn method();
+}
+
+fn main() {}

--- a/tests/ui/attr-in-sync-method.stderr
+++ b/tests/ui/attr-in-sync-method.stderr
@@ -1,0 +1,5 @@
+error: #[async_trait] is not allowed in sync methods
+ --> tests/ui/attr-in-sync-method.rs:5:5
+  |
+5 |     #[async_trait(?Send)]
+  |     ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/duplicate-method-attributes.rs
+++ b/tests/ui/duplicate-method-attributes.rs
@@ -1,0 +1,11 @@
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait Trait {
+    #[async_trait(?Send)]
+    #[async_trait(?Send)]
+    async fn method();
+}
+
+fn main() {}
+

--- a/tests/ui/duplicate-method-attributes.stderr
+++ b/tests/ui/duplicate-method-attributes.stderr
@@ -1,0 +1,5 @@
+error: duplicate #[async_trait] in method
+ --> tests/ui/duplicate-method-attributes.rs:6:5
+  |
+6 |     #[async_trait(?Send)]
+  |     ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/invalid-method-attributes.rs
+++ b/tests/ui/invalid-method-attributes.rs
@@ -1,0 +1,22 @@
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait Trait {
+    #[async_trait]
+    async fn method();
+}
+
+#[async_trait]
+pub trait Trait2 {
+    #[async_trait(invalid)]
+    async fn method();
+}
+
+#[async_trait]
+pub trait Trait3 {
+    #[async_trait = "invalid"]
+    async fn method();
+}
+
+fn main() {}
+

--- a/tests/ui/invalid-method-attributes.stderr
+++ b/tests/ui/invalid-method-attributes.stderr
@@ -1,0 +1,17 @@
+error: expected attribute arguments in parentheses: #[async_trait(...)]
+ --> tests/ui/invalid-method-attributes.rs:5:5
+  |
+5 |     #[async_trait]
+  |     ^^^^^^^^^^^^^^
+
+error: expected #[async_trait(?Send)]
+  --> tests/ui/invalid-method-attributes.rs:11:5
+   |
+11 |     #[async_trait(invalid)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected parentheses: #[async_trait(...)]
+  --> tests/ui/invalid-method-attributes.rs:17:5
+   |
+17 |     #[async_trait = "invalid"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/method-attr-outside-async-trait.rs
+++ b/tests/ui/method-attr-outside-async-trait.rs
@@ -1,0 +1,8 @@
+use async_trait::async_trait;
+
+pub trait Trait {
+    #[async_trait(?Send)]
+    async fn method();
+}
+
+fn main() {}

--- a/tests/ui/method-attr-outside-async-trait.stderr
+++ b/tests/ui/method-attr-outside-async-trait.stderr
@@ -1,0 +1,8 @@
+error: invalid item for #[async_trait]: expected one of: `unsafe`, `pub`, `trait`, `impl`.
+       Did you forget #[async_trait] on the outer trait or impl block?
+ --> tests/ui/method-attr-outside-async-trait.rs:4:5
+  |
+4 |     #[async_trait(?Send)]
+  |     ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `async_trait` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/missing-send-attr-in-impl.rs
+++ b/tests/ui/missing-send-attr-in-impl.rs
@@ -1,0 +1,16 @@
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait Trait {
+    #[async_trait(?Send)]
+    async fn method();
+}
+
+pub struct Struct;
+
+#[async_trait]
+impl Trait for Struct {
+    async fn method() {}
+}
+
+fn main() {}

--- a/tests/ui/missing-send-attr-in-impl.stderr
+++ b/tests/ui/missing-send-attr-in-impl.stderr
@@ -1,0 +1,13 @@
+error[E0053]: method `method` has an incompatible type for trait
+  --> tests/ui/missing-send-attr-in-impl.rs:13:5
+   |
+13 |     async fn method() {}
+   |     ^^^^^^^^^^^^^^^^^ expected trait `Future<Output = ()>`, found trait `Future<Output = ()> + Send`
+   |
+note: type in trait
+  --> tests/ui/missing-send-attr-in-impl.rs:6:5
+   |
+6  |     async fn method();
+   |     ^^^^^^^^^^^^^^^^^^
+   = note: expected fn pointer `fn() -> Pin<Box<(dyn Future<Output = ()> + 'async_trait)>>`
+              found fn pointer `fn() -> Pin<Box<(dyn Future<Output = ()> + Send + 'async_trait)>>`

--- a/tests/ui/missing-send-attr-in-trait.rs
+++ b/tests/ui/missing-send-attr-in-trait.rs
@@ -1,0 +1,16 @@
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait Trait {
+    async fn method();
+}
+
+pub struct Struct;
+
+#[async_trait]
+impl Trait for Struct {
+    #[async_trait(?Send)]
+    async fn method() {}
+}
+
+fn main() {}

--- a/tests/ui/missing-send-attr-in-trait.stderr
+++ b/tests/ui/missing-send-attr-in-trait.stderr
@@ -1,0 +1,13 @@
+error[E0053]: method `method` has an incompatible type for trait
+  --> tests/ui/missing-send-attr-in-trait.rs:13:5
+   |
+13 |     async fn method() {}
+   |     ^^^^^^^^^^^^^^^^^ expected trait `Future<Output = ()> + Send`, found trait `Future<Output = ()>`
+   |
+note: type in trait
+  --> tests/ui/missing-send-attr-in-trait.rs:5:5
+   |
+5  |     async fn method();
+   |     ^^^^^^^^^^^^^^^^^^
+   = note: expected fn pointer `fn() -> Pin<Box<(dyn Future<Output = ()> + Send + 'async_trait)>>`
+              found fn pointer `fn() -> Pin<Box<(dyn Future<Output = ()> + 'async_trait)>>`

--- a/tests/ui/multiple-method-attr-errors.rs
+++ b/tests/ui/multiple-method-attr-errors.rs
@@ -1,0 +1,18 @@
+use async_trait::async_trait;
+
+#[async_trait(?Send)]
+pub trait Trait {
+    #[async_trait(?Send)]
+    #[async_trait]
+    #[async_trait(?Send)]
+    async fn method();
+}
+
+#[async_trait]
+pub trait Trait2 {
+    #[async_trait(?Send)]
+    #[async_trait(?Send)]
+    async fn method();
+}
+
+fn main() {}

--- a/tests/ui/multiple-method-attr-errors.stderr
+++ b/tests/ui/multiple-method-attr-errors.stderr
@@ -1,0 +1,23 @@
+error: duplicate #[async_trait] in method
+ --> tests/ui/multiple-method-attr-errors.rs:6:5
+  |
+6 |     #[async_trait]
+  |     ^^^^^^^^^^^^^^
+
+error: duplicate #[async_trait] in method
+ --> tests/ui/multiple-method-attr-errors.rs:7:5
+  |
+7 |     #[async_trait(?Send)]
+  |     ^^^^^^^^^^^^^^^^^^^^^
+
+error: redundant #[async_trait(?Send)] in method
+ --> tests/ui/multiple-method-attr-errors.rs:5:5
+  |
+5 |     #[async_trait(?Send)]
+  |     ^^^^^^^^^^^^^^^^^^^^^
+
+error: duplicate #[async_trait] in method
+  --> tests/ui/multiple-method-attr-errors.rs:14:5
+   |
+14 |     #[async_trait(?Send)]
+   |     ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/redundant-send.rs
+++ b/tests/ui/redundant-send.rs
@@ -1,0 +1,17 @@
+use async_trait::async_trait;
+
+#[async_trait(?Send)]
+pub trait Trait {
+    #[async_trait(?Send)]
+    async fn method();
+}
+
+pub struct Struct;
+
+#[async_trait(?Send)]
+impl Trait for Struct {
+    #[async_trait(?Send)]
+    async fn method() {}
+}
+
+fn main() {}

--- a/tests/ui/redundant-send.stderr
+++ b/tests/ui/redundant-send.stderr
@@ -1,0 +1,11 @@
+error: redundant #[async_trait(?Send)] in method
+ --> tests/ui/redundant-send.rs:5:5
+  |
+5 |     #[async_trait(?Send)]
+  |     ^^^^^^^^^^^^^^^^^^^^^
+
+error: redundant #[async_trait(?Send)] in method
+  --> tests/ui/redundant-send.rs:13:5
+   |
+13 |     #[async_trait(?Send)]
+   |     ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #131

Allow adding `#[async_trait(?Send)]` to specific methods instead of the whole trait for cases where only some methods require `Send` bounds.

I could add `#[async_trait(Send)]` as well for convenience when most methods on a trait should be `?Send` but a few shouldn't, depending on your opnion on that.