### PR TITLE
Tag the inserted lifetime bounds with the span of the other bounds

### DIFF
--- a/tests/ui/issue-93828.rs
+++ b/tests/ui/issue-93828.rs
@@ -1,0 +1,31 @@
+use async_trait::async_trait;
+
+struct Client;
+struct Client2;
+trait IntoUrl {}
+
+#[async_trait]
+pub trait ClientExt {
+    async fn publish<T: IntoUrl>(&self, url: T) -> String;
+}
+
+// https://github.com/rust-lang/rust/issues/93828
+#[async_trait]
+impl ClientExt for Client {
+    async fn publish<T: IntoUrl>(&self, url: T) -> String {
+        "Foo".to_string()
+    }
+}
+
+// Variant test case with no bounds at all.
+// This doesn't actually work correctly yet. It ought to insert the colon,
+// but getting it to do that would require a way to tell rustc that the bounds
+// don't actually exist in the source code, and it needs to insert them.
+#[async_trait]
+impl ClientExt for Client2 {
+    async fn publish<T>(&self, url: T) -> String {
+        "Foo".to_string()
+    }
+}
+
+fn main() {}

--- a/tests/ui/issue-93828.stderr
+++ b/tests/ui/issue-93828.stderr
@@ -1,0 +1,39 @@
+error: future cannot be sent between threads safely
+  --> tests/ui/issue-93828.rs:15:59
+   |
+15 |       async fn publish<T: IntoUrl>(&self, url: T) -> String {
+   |  ___________________________________________________________^
+16 | |         "Foo".to_string()
+17 | |     }
+   | |_____^ future created by async block is not `Send`
+   |
+note: captured value is not `Send`
+  --> tests/ui/issue-93828.rs:15:41
+   |
+15 |     async fn publish<T: IntoUrl>(&self, url: T) -> String {
+   |                                         ^^^ has type `T` which is not `Send`
+   = note: required for the cast to the object type `dyn Future<Output = String> + Send`
+help: consider further restricting this bound
+   |
+15 |     async fn publish<T: IntoUrl + std::marker::Send>(&self, url: T) -> String {
+   |                                 +++++++++++++++++++
+
+error: future cannot be sent between threads safely
+  --> tests/ui/issue-93828.rs:26:50
+   |
+26 |       async fn publish<T>(&self, url: T) -> String {
+   |  __________________________________________________^
+27 | |         "Foo".to_string()
+28 | |     }
+   | |_____^ future created by async block is not `Send`
+   |
+note: captured value is not `Send`
+  --> tests/ui/issue-93828.rs:26:32
+   |
+26 |     async fn publish<T>(&self, url: T) -> String {
+   |                                ^^^ has type `T` which is not `Send`
+   = note: required for the cast to the object type `dyn Future<Output = String> + Send`
+help: consider further restricting this bound
+   |
+26 |     async fn publish<T + std::marker::Send>(&self, url: T) -> String {
+   |                        +++++++++++++++++++


### PR DESCRIPTION
Fixes rust-lang/rust#93828 (which is really a bug in `async_trait`, not rustc).

Before:

	help: consider further restricting this bound
	   |
	13 |     async fn publish<T + std::marker::Send: IntoUrl>(&self, url: T) -> String {
	   |                        +++++++++++++++++++

After:

	help: consider further restricting this bound
	   |
	13 |     async fn publish<T: IntoUrl + std::marker::Send>(&self, url: T) -> String {
	   |                                 +++++++++++++++++++