### PR TITLE
Move bounds from generic param list to where-clause after 'async_trait bound

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -8,8 +8,8 @@ use syn::punctuated::Punctuated;
 use syn::visit_mut::{self, VisitMut};
 use syn::{
     parse_quote, parse_quote_spanned, Attribute, Block, FnArg, GenericParam, Generics, Ident,
-    ImplItem, Lifetime, Pat, PatIdent, Receiver, ReturnType, Signature, Stmt, Token, TraitItem,
-    Type, TypeParamBound, TypePath, WhereClause,
+    ImplItem, Lifetime, LifetimeDef, Pat, PatIdent, Receiver, ReturnType, Signature, Stmt, Token,
+    TraitItem, Type, TypeParamBound, TypePath, WhereClause,
 };
 
 impl ToTokens for Item {
@@ -34,17 +34,18 @@ enum Context<'a> {
 }
 
 impl Context<'_> {
-    fn lifetimes<'a>(&'a self, used: &'a [Lifetime]) -> impl Iterator<Item = &'a GenericParam> {
+    fn lifetimes<'a>(&'a self, used: &'a [Lifetime]) -> impl Iterator<Item = &'a LifetimeDef> {
         let generics = match self {
             Context::Trait { generics, .. } => generics,
             Context::Impl { impl_generics, .. } => impl_generics,
         };
-        generics.params.iter().filter(move |param| {
+        generics.params.iter().filter_map(move |param| {
             if let GenericParam::Lifetime(param) = param {
-                used.contains(&param.lifetime)
-            } else {
-                false
+                if used.contains(&param.lifetime) {
+                    return Some(param);
+                }
             }
+            None
         })
     }
 }
@@ -178,12 +179,7 @@ fn transform_sig(
         }
     }
 
-    for param in sig
-        .generics
-        .params
-        .iter()
-        .chain(context.lifetimes(&lifetimes.explicit))
-    {
+    for param in &sig.generics.params {
         match param {
             GenericParam::Type(param) => {
                 let param = &param.ident;
@@ -201,6 +197,14 @@ fn transform_sig(
             }
             GenericParam::Const(_) => {}
         }
+    }
+
+    for param in context.lifetimes(&lifetimes.explicit) {
+        let param = &param.lifetime;
+        let span = param.span();
+        where_clause_or_default(&mut sig.generics.where_clause)
+            .predicates
+            .push(parse_quote_spanned!(span=> #param: 'async_trait));
     }
 
     if sig.generics.lt_token.is_none() {

--- a/tests/ui/consider-restricting.stderr
+++ b/tests/ui/consider-restricting.stderr
@@ -12,8 +12,8 @@ note: captured value is not `Send`
    = note: required for the cast to the object type `dyn Future<Output = ()> + Send`
 help: consider further restricting this bound
    |
-16 |     async fn publish<T + std::marker::Send: IntoUrl>(&self, url: T) {}
-   |                        +++++++++++++++++++
+16 |     async fn publish<T: IntoUrl + std::marker::Send>(&self, url: T) {}
+   |                                 +++++++++++++++++++
 
 error: future cannot be sent between threads safely
   --> tests/ui/consider-restricting.rs:23:40


### PR DESCRIPTION
I experimented with this as an alternative to #191. There are a few diagnostics that this still makes worse, but I think this one is an improvement often enough that I think it's worth trying.

Here is what it does to the expanded code from the ui test:

```diff
-  fn publish<'life0, 'async_trait, T: IntoUrl>(
+  fn publish<'life0, 'async_trait, T>(
       &'life0 self,
       url: T,
   ) -> ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> + ::core::marker::Send + 'async_trait>>
   where
-      T: 'async_trait,
+      T: 'async_trait + IntoUrl,
       'life0: 'async_trait,
       Self: 'async_trait,
   {…}
```

Since we've inserted `'async_trait +` at the beginning of the bounds list, instead of `+ 'async_trait` at the end, when rustc goes to add more bounds they'll appear correctly after the last user-written bound in the source code.