### PR TITLE
feat(unboxed_simple): unboxed_simple for wider coverage

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -595,7 +595,7 @@ fn define_implicit_associated_type(
         sig.ident
     );
     let mut implicit_type_def: TraitItemType = parse_quote!(
-        #[allow(clippy::type_repetition_in_bounds)]
+        #[allow(clippy::needless_lifetimes, clippy::type_repetition_in_bounds)]
         #[doc = #generated_doc]
         type #implicit_type_name: ::core::future::Future<Output = #ret> + #bounds;
     );
@@ -630,7 +630,7 @@ fn assign_implicit_associated_type(
         sig.ident
     );
     let mut implicit_type_assign: ImplItemType = parse_quote!(
-        #[allow(clippy::type_repetition_in_bounds)]
+        #[allow(clippy::needless_lifetimes, clippy::type_repetition_in_bounds)]
         #[doc = #generated_doc]
         type #implicit_type_name = impl ::core::future::Future<Output = #ret> + #bounds;
     );

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -9,8 +9,8 @@ use syn::punctuated::Punctuated;
 use syn::visit_mut::{self, VisitMut};
 use syn::{
     parse_quote, parse_quote_spanned, Attribute, Block, FnArg, GenericParam, Generics, Ident,
-    ImplItem, Lifetime, LifetimeDef, Pat, PatIdent, Receiver, ReturnType, Signature, Stmt, Token,
-    TraitItem, TraitItemType, Type, TypeParamBound, TypePath, WhereClause,
+    ImplItem, ImplItemType, Lifetime, LifetimeDef, Pat, PatIdent, Receiver, ReturnType, Signature,
+    Stmt, Token, TraitItem, TraitItemType, Type, TypeParamBound, TypePath, WhereClause,
 };
 
 impl ToTokens for Item {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,3 +381,8 @@ pub fn async_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 pub fn static_future(_args: TokenStream, input: TokenStream) -> TokenStream {
     input
 }
+
+#[proc_macro_attribute]
+pub fn reconciled_static_future(_args: TokenStream, input: TokenStream) -> TokenStream {
+    input
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,9 @@ pub fn async_trait(args: TokenStream, input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(args as Args);
     let mut item = parse_macro_input!(input as Item);
     expand(&mut item, args.local);
-    TokenStream::from(quote!(#item))
+    let ts = TokenStream::from(quote!(#item));
+    println!("{ts}");
+    ts
 }
 
 #[proc_macro_attribute]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,12 +303,12 @@
 //! let object = &value as &dyn ObjectSafe;
 //! ```
 //!
-//! # Experimental feature: `static_future`
+//! # Experimental feature: `unboxed`
 //!
 //! An `async fn` without a default implementation may get transformed into a
 //! method that returns `impl Future + Send + 'async_trait` when
-//! `#[macro@static_future]` is invoked on both the trait and the impl blocks.
-//! `#[macro@static_future]` requires the following unstable language features:
+//! `#[macro@unboxed]` is invoked on both the trait and the impl blocks.
+//! `#[macro@unboxed]` requires the following unstable language features:
 //! `associated_type_bounds`, `generic_associated_types`, and
 //! `type_alias_impl_trait`.
 //!
@@ -323,7 +323,7 @@
 //! #[async_trait]
 //! pub trait MyFastTrait {
 //!     /// `cnt_fast` returns an instance of a concrete `Future` type.
-//!     #[static_future]
+//!     #[unboxed]
 //!     async fn cnt_fast(&self) -> usize;
 //!
 //!     // presumably other methods
@@ -333,14 +333,14 @@
 //!
 //! #[async_trait]
 //! impl MyFastTrait for MyType {
-//!     #[static_future]
+//!     #[unboxed]
 //!     async fn cnt_fast(&self) -> usize {
 //!         self.0
 //!     }
 //! }
 //!
 //! let value = MyType(1);
-//! let static_future = value.cnt_fast();
+//! let unboxed_future = value.cnt_fast();
 //! ```
 
 #![allow(
@@ -374,9 +374,7 @@ pub fn async_trait(args: TokenStream, input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(args as Args);
     let mut item = parse_macro_input!(input as Item);
     expand(&mut item, args.local);
-    let ts = TokenStream::from(quote!(#item));
-    println!("{ts}");
-    ts
+    TokenStream::from(quote!(#item))
 }
 
 #[proc_macro_attribute]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,11 +380,11 @@ pub fn async_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-pub fn static_future(_args: TokenStream, input: TokenStream) -> TokenStream {
+pub fn unboxed(_args: TokenStream, input: TokenStream) -> TokenStream {
     input
 }
 
 #[proc_macro_attribute]
-pub fn reconciled_static_future(_args: TokenStream, input: TokenStream) -> TokenStream {
+pub fn unboxed_simple(_args: TokenStream, input: TokenStream) -> TokenStream {
     input
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -639,31 +639,22 @@ pub mod static_future_nosend {
 
 //#[cfg(async_trait_nightly_testing)]
 #[allow(dead_code)]
-pub mod static_future_lifetime {
+pub mod static_future_reconciled {
     use crate::executor;
+    use async_trait::{async_trait, reconciled_static_future};
     use std::future::Future;
 
+    #[async_trait]
     pub trait Get: Send + Sync {
-        type Ret<'a>: Future<Output = usize> + Send + 'a
-        where
-            Self: 'a;
-
-        fn get<'a>(&'a self) -> Self::Ret<'a>
-        where
-            Self: 'a;
+        #[reconciled_static_future]
+        async fn get<'a>(&'a self) -> usize;
     }
 
+    #[async_trait]
     impl Get for usize {
-        type Ret<'a>
-        where
-            Self: 'a,
-        = impl Future<Output = usize> + Send + 'a;
-
-        fn get<'a>(&'a self) -> Self::Ret<'a>
-        where
-            Self: 'a,
-        {
-            async move { *self }
+        #[reconciled_static_future]
+        async fn get<'a>(&'a self) -> usize {
+            *self
         }
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -245,11 +245,11 @@ pub async fn test_unimplemented() {
 }
 
 // #[cfg(async_trait_nightly_testing)]
-pub mod static_future {
+pub mod unboxed {
     use std::usize;
 
     use crate::executor;
-    use async_trait::{async_trait, static_future};
+    use async_trait::{async_trait, unboxed};
 
     #[derive(Default)]
     pub struct F(usize);
@@ -268,7 +268,7 @@ pub mod static_future {
         /// # Panics
         ///
         /// None.
-        #[async_trait::static_future]
+        #[async_trait::unboxed]
         async fn add_u8(&self, u: u8) -> usize;
 
         async fn add_u8_1_wrap(&self) -> usize;
@@ -282,28 +282,28 @@ pub mod static_future {
         /// # Panics
         ///
         /// None.
-        #[static_future]
+        #[unboxed]
         async fn add_usize_mut<'u>(&self, u: &'u mut usize) -> (&'u mut usize, usize);
 
-        #[static_future]
+        #[unboxed]
         async fn sum_array(&self, u: &[u8]) -> usize;
 
-        #[static_future]
+        #[unboxed]
         async fn get_len(&mut self, s: &str) -> usize;
 
-        #[static_future]
+        #[unboxed]
         async fn sum_len(&mut self, s1: &str, s2: &str) -> usize;
 
-        #[static_future]
+        #[unboxed]
         async fn get_usize_ref<'s>(&'s self) -> &'s usize;
 
-        #[static_future]
+        #[unboxed]
         async fn clone_ret_pair<T: Clone + Copy + Send>(&self, t: T) -> (usize, T);
 
-        #[static_future]
+        #[unboxed]
         async fn reset_t_mut<'t, T: Default + Send + Sync>(&self, t: &'t mut T) -> &'t mut T;
 
-        #[static_future]
+        #[unboxed]
         async fn no_self<'t, 'y, T: Default + Send + Sync, Y: Clone + Sync>(
             t_mut: &'t mut T,
             y_ref: &'y Y,
@@ -313,7 +313,7 @@ pub mod static_future {
     #[async_trait]
     impl FastAsyncTrait for F {
         /// It implements [`FastAsyncTrait::add_u8`].
-        #[static_future]
+        #[unboxed]
         async fn add_u8(&self, u: u8) -> usize {
             self.0 + (u as usize)
         }
@@ -322,25 +322,25 @@ pub mod static_future {
             self.add_u8(1).await
         }
 
-        #[static_future]
+        #[unboxed]
         async fn add_usize_mut<'u>(&self, u: &'u mut usize) -> (&'u mut usize, usize) {
             (*u) += self.0;
             (u, self.0)
         }
 
         /// It implements [`FastAsyncTrait::sum_array`].
-        #[static_future]
+        #[unboxed]
         async fn sum_array(&self, u: &[u8]) -> usize {
             u.iter().sum::<u8>() as usize
         }
 
-        #[static_future]
+        #[unboxed]
         async fn get_len(&mut self, s: &str) -> usize {
             self.0 = s.len();
             self.0
         }
 
-        #[static_future]
+        #[unboxed]
         async fn sum_len(&mut self, s1: &str, s2: &str) -> usize {
             let len1 = self.get_len(s1).await;
             let len2 = self.get_len(s2).await;
@@ -348,23 +348,23 @@ pub mod static_future {
             self.0
         }
 
-        #[static_future]
+        #[unboxed]
         async fn get_usize_ref<'s>(&'s self) -> &'s usize {
             &self.0
         }
 
-        #[static_future]
+        #[unboxed]
         async fn clone_ret_pair<T: Clone + Copy + Send>(&self, t: T) -> (usize, T) {
             (self.0, t)
         }
 
-        #[static_future]
+        #[unboxed]
         async fn reset_t_mut<'t, T: Default + Send + Sync>(&self, t: &'t mut T) -> &'t mut T {
             *t = T::default();
             t
         }
 
-        #[static_future]
+        #[unboxed]
         async fn no_self<'t, 'y, T: Default + Send + Sync, Y: Clone + Sync>(
             t_mut: &'t mut T,
             y_ref: &'y Y,
@@ -459,19 +459,19 @@ pub mod static_future {
 }
 
 //#[cfg(async_trait_nightly_testing)]
-pub mod static_future_dep {
+pub mod unboxed_dep {
     use crate::executor;
-    use async_trait::{async_trait, static_future};
+    use async_trait::{async_trait, unboxed};
 
     #[async_trait]
     pub trait AsyncIter {
-        #[static_future]
+        #[unboxed]
         async fn next(&mut self) -> Option<usize>;
     }
     struct A(usize);
     #[async_trait]
     impl AsyncIter for A {
-        #[static_future]
+        #[unboxed]
         async fn next(&mut self) -> Option<usize> {
             if self.0 > 0 {
                 self.0 -= 1;
@@ -547,9 +547,9 @@ pub mod static_future_dep {
 }
 
 // #[cfg(async_trait_nightly_testing)]
-pub mod static_future_pinned {
+pub mod unboxed_pinned {
     use crate::executor;
-    use async_trait::{async_trait, static_future};
+    use async_trait::{async_trait, unboxed};
 
     struct F(*const usize, std::marker::PhantomPinned);
     unsafe impl Send for F {}
@@ -561,13 +561,13 @@ pub mod static_future_pinned {
 
     #[async_trait]
     pub trait FastAsyncTrait {
-        #[static_future]
+        #[unboxed]
         async fn get_ref<'s>(&'s self, g: G) -> (&'s usize, usize);
     }
 
     #[async_trait]
     impl FastAsyncTrait for F {
-        #[static_future]
+        #[unboxed]
         async fn get_ref<'s>(&'s self, g: G) -> (&'s usize, usize) {
             unsafe { (&*self.0, *g.0) }
         }
@@ -605,21 +605,21 @@ pub mod static_future_pinned {
 }
 
 //#[cfg(async_trait_nightly_testing)]
-pub mod static_future_nosend {
+pub mod unboxed_nosend {
     use crate::executor;
-    use async_trait::{async_trait, static_future};
+    use async_trait::{async_trait, unboxed};
 
     struct F(*mut usize);
 
     #[async_trait(?Send)]
     pub trait FastAsyncTrait {
-        #[static_future]
+        #[unboxed]
         async fn add<'s>(&'s mut self, a: usize);
     }
 
     #[async_trait(?Send)]
     impl FastAsyncTrait for F {
-        #[static_future]
+        #[unboxed]
         async fn add<'s>(&'s mut self, a: usize) {
             unsafe {
                 (*self.0) += a;
@@ -638,21 +638,20 @@ pub mod static_future_nosend {
 }
 
 //#[cfg(async_trait_nightly_testing)]
-#[allow(dead_code)]
-pub mod static_future_reconciled {
+pub mod unboxed_simple {
     use crate::executor;
-    use async_trait::{async_trait, reconciled_static_future};
+    use async_trait::{async_trait, unboxed_simple};
     use std::future::Future;
 
     #[async_trait]
     pub trait Get: Send + Sync {
-        #[reconciled_static_future]
+        #[unboxed_simple]
         async fn get<'a>(&'a self) -> usize;
     }
 
     #[async_trait]
     impl Get for usize {
-        #[reconciled_static_future]
+        #[unboxed_simple]
         async fn get<'a>(&'a self) -> usize {
             *self
         }


### PR DESCRIPTION
unboxed_simple substitutes all the lifetime bounds with 'async_trait and remove all the lifetime bounds except for one 'async_trait in async trait methods and imply.