### PR TITLE
Disable test of tracing attrs on miri due to once_cell

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -618,6 +618,7 @@ pub mod issue45 {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // https://github.com/matklad/once_cell/pull/185
     fn tracing() {
         // Create the future outside of the subscriber, as no call to tracing
         // should be made until the future is polled.


### PR DESCRIPTION
```console
$ MIRIFLAGS=-Zmiri-strict-provenance cargo miri test

test issue45::tracing ... error: unsupported operation: integer-to-pointer casts and `ptr::from_exposed_addr` are not supported with `-Zmiri-strict-provenance`
   --> github.com-1ecc6299db9ec823/once_cell-1.12.0/src/imp_std.rs:175:30
    |
175 |             let mut waiter = (queue & !STATE_MASK) as *const Waiter;
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ integer-to-pointer casts and `ptr::from_exposed_addr` are not supported with `-Zmiri-strict-provenance`
    |
    = help: use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead

    = note: inside `<once_cell::imp::Guard as std::ops::Drop>::drop` at github.com-1ecc6299db9ec823/once_cell-1.12.0/src/imp_std.rs:175:30
    = note: inside `std::ptr::drop_in_place::<once_cell::imp::Guard> - shim(Some(once_cell::imp::Guard))` at nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:487:1
    = note: inside `once_cell::imp::initialize_or_wait` at github.com-1ecc6299db9ec823/once_cell-1.12.0/src/imp_std.rs:217:13
    = note: inside `once_cell::imp::OnceCell::<std::sync::RwLock<std::vec::Vec<tracing_core::dispatcher::Registrar>>>::initialize::<[closure@once_cell::sync::OnceCell<std::sync::RwLock<std::vec::Vec<tracing_core::dispatcher::Registrar>>>::get_or_init<[closure@once_cell::sync::Lazy<std::sync::RwLock<std::vec::Vec<tracing_core::dispatcher::Registrar>>>::force::{closure#0}]>::{closure#0}], once_cell::sync::OnceCell<T>::get_or_init::Void>` at github.com-1ecc6299db9ec823/once_cell-1.12.0/src/imp_std.rs:81:9
    = note: inside `once_cell::sync::OnceCell::<std::sync::RwLock<std::vec::Vec<tracing_core::dispatcher::Registrar>>>::get_or_try_init::<[closure@once_cell::sync::OnceCell<std::sync::RwLock<std::vec::Vec<tracing_core::dispatcher::Registrar>>>::get_or_init<[closure@once_cell::sync::Lazy<std::sync::RwLock<std::vec::Vec<tracing_core::dispatcher::Registrar>>>::force::{closure#0}]>::{closure#0}], once_cell::sync::OnceCell<T>::get_or_init::Void>` at github.com-1ecc6299db9ec823/once_cell-1.12.0/src/lib.rs:1063:13
    = note: inside `once_cell::sync::OnceCell::<std::sync::RwLock<std::vec::Vec<tracing_core::dispatcher::Registrar>>>::get_or_init::<[closure@once_cell::sync::Lazy<std::sync::RwLock<std::vec::Vec<tracing_core::dispatcher::Registrar>>>::force::{closure#0}]>` at github.com-1ecc6299db9ec823/once_cell-1.12.0/src/lib.rs:1023:19
    = note: inside `once_cell::sync::Lazy::<std::sync::RwLock<std::vec::Vec<tracing_core::dispatcher::Registrar>>>::force` at github.com-1ecc6299db9ec823/once_cell-1.12.0/src/lib.rs:1211:13
    = note: inside `<once_cell::sync::Lazy<std::sync::RwLock<std::vec::Vec<tracing_core::dispatcher::Registrar>>> as std::ops::Deref>::deref` at github.com-1ecc6299db9ec823/once_cell-1.12.0/src/lib.rs:1221:13
    = note: inside `tracing::callsite::dispatchers::Dispatchers::register_dispatch` at github.com-1ecc6299db9ec823/tracing-core-0.1.28/src/callsite.rs:545:35
    = note: inside `tracing::callsite::register_dispatch` at github.com-1ecc6299db9ec823/tracing-core-0.1.28/src/callsite.rs:480:23
    = note: inside `tracing::Dispatch::new::<issue45::TestSubscriber>` at github.com-1ecc6299db9ec823/tracing-core-0.1.28/src/dispatcher.rs:413:9
    = note: inside `tracing::subscriber::with_default::<(), issue45::TestSubscriber, [closure@tests/test.rs:627:54: 627:87]>` at github.com-1ecc6299db9ec823/tracing-0.1.35/src/subscriber.rs:24:38
note: inside `issue45::tracing` at tests/test.rs:627:9
   --> tests/test.rs:627:9
    |
627 |         subscriber::with_default(subscriber.clone(), || executor::block_on_simple(fut));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure at tests/test.rs:621:5
   --> tests/test.rs:621:5
    |
620 |       #[test]
    |       ------- in this procedural macro expansion
621 | /     fn tracing() {
622 | |         // Create the future outside of the subscriber, as no call to tracing
623 | |         // should be made until the future is polled.
624 | |         let mut struct_impl = Impl(0);
...   |
636 | |         assert_eq!(*subscriber.inner.value.lock().unwrap(), Some(("val", 5, 2)));
637 | |     }
    | |_____^
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
```

I confirmed that this is fixed by https://github.com/matklad/once_cell/pull/185, so we can re-enable after that PR is merged and released by once_cell.