### PR TITLE
README: Clarify description of non-threadsafe futures

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,10 @@ impl Advertisement for AutoplayingVideo {
 
 ## Non-threadsafe futures
 
-Not all async traits need futures that are `dyn Future + Send`. To avoid having
-Send and Sync bounds placed on the async trait methods, invoke the async trait
-macro as `#[async_trait(?Send)]` on both the trait and the impl blocks.
+Not all async traits need futures that are `dyn Future + Send` (that is, threadsafe
+futures).  To create non-threadsafe async trait methods (without Send and Sync
+bounds), invoke the async trait macro as `#[async_trait(?Send)]` on both the trait
+and the impl blocks.
 
 <br>
 


### PR DESCRIPTION
The paragraph describing non-threadsafe futures is a bit confusing. 

Clarify that one may use `#[async_trait(?Send)]` to create _non-threadsafe_ methods.

----

CC: @fitzthum
