### PR TITLE
Add `+Sync` argument to mark the future as `Sync`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -5,10 +5,12 @@ use syn::Token;
 #[derive(Copy, Clone)]
 pub struct Args {
     pub local: bool,
+    pub sync: bool,
 }
 
 mod kw {
     syn::custom_keyword!(Send);
+    syn::custom_keyword!(Sync);
 }
 
 impl Parse for Args {
@@ -24,9 +26,22 @@ fn try_parse(input: ParseStream) -> Result<Args> {
     if input.peek(Token![?]) {
         input.parse::<Token![?]>()?;
         input.parse::<kw::Send>()?;
-        Ok(Args { local: true })
+        Ok(Args {
+            local: true,
+            sync: false,
+        })
+    } else if input.peek(Token![+]) {
+        input.parse::<Token![+]>()?;
+        input.parse::<kw::Sync>()?;
+        Ok(Args {
+            local: false,
+            sync: true,
+        })
     } else {
-        Ok(Args { local: false })
+        Ok(Args {
+            local: false,
+            sync: false,
+        })
     }
 }
 

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -53,7 +53,7 @@ impl Context<'_> {
 
 type Supertraits = Punctuated<TypeParamBound, Token![+]>;
 
-pub fn expand(input: &mut Item, is_local: bool) {
+pub fn expand(input: &mut Item, is_local: bool, is_sync: bool) {
     match input {
         Item::Trait(input) => {
             let context = Context::Trait {
@@ -75,7 +75,7 @@ pub fn expand(input: &mut Item, is_local: bool) {
                             method.attrs.push(lint_suppress_without_body());
                         }
                         let has_default = method.default.is_some();
-                        transform_sig(context, sig, has_self, has_default, is_local);
+                        transform_sig(context, sig, has_self, has_default, is_local, is_sync);
                     }
                 }
             }
@@ -108,7 +108,7 @@ pub fn expand(input: &mut Item, is_local: bool) {
                         let block = &mut method.block;
                         let has_self = has_self_in_sig(sig) || has_self_in_block(block);
                         transform_block(context, sig, block);
-                        transform_sig(context, sig, has_self, false, is_local);
+                        transform_sig(context, sig, has_self, false, is_local, is_sync);
                         method.attrs.push(lint_suppress_with_body());
                     }
                 }
@@ -158,6 +158,7 @@ fn transform_sig(
     has_self: bool,
     has_default: bool,
     is_local: bool,
+    is_sync: bool,
 ) {
     sig.fn_token.span = sig.asyncness.take().unwrap().span;
 
@@ -292,7 +293,11 @@ fn transform_sig(
     let bounds = if is_local {
         quote_spanned!(ret_span=> 'async_trait)
     } else {
-        quote_spanned!(ret_span=> ::core::marker::Send + 'async_trait)
+        if is_sync {
+            quote_spanned!(ret_span=> ::core::marker::Send + ::core::marker::Sync + 'async_trait)
+        } else {
+            quote_spanned!(ret_span=> ::core::marker::Send + 'async_trait)
+        }
     };
     sig.output = parse_quote_spanned! {ret_span=>
         -> ::core::pin::Pin<Box<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,6 @@ use syn::parse_macro_input;
 pub fn async_trait(args: TokenStream, input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(args as Args);
     let mut item = parse_macro_input!(input as Item);
-    expand(&mut item, args.local);
+    expand(&mut item, args.local, args.sync);
     TokenStream::from(quote!(#item))
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1451,3 +1451,32 @@ pub mod issue204 {
         async fn g(arg: *const impl Trait);
     }
 }
+
+// https://github.com/dtolnay/async-trait/issues/77
+pub mod issue77 {
+    use async_trait::async_trait;
+
+    #[async_trait(+Sync)]
+    pub trait Trait {
+        async fn f(&self);
+    }
+
+    struct A;
+
+    #[async_trait(+Sync)]
+    impl Trait for A {
+        async fn f(&self) {}
+    }
+
+    #[test]
+    fn test() {
+        fn inner_test<T>(_: T)
+        where
+            T: Send + Sync,
+        {
+        }
+
+        let fut = A.f();
+        inner_test(fut);
+    }
+}

--- a/tests/ui/sync.rs
+++ b/tests/ui/sync.rs
@@ -1,0 +1,18 @@
+use async_trait::async_trait;
+
+struct A;
+
+#[async_trait]
+pub trait Trait {
+    async fn method(&self);
+}
+
+#[async_trait]
+impl Trait for A {
+    async fn method(&self) {}
+}
+
+fn main() {
+    fn test<T>(a: T) where T: Trait + Send + Sync  {}
+    test(A.method());
+}

--- a/tests/ui/sync.stderr
+++ b/tests/ui/sync.stderr
@@ -1,0 +1,32 @@
+error[E0277]: the trait bound `Pin<Box<dyn Future<Output = ()> + Send>>: Trait` is not satisfied
+  --> tests/ui/sync.rs:17:10
+   |
+17 |     test(A.method());
+   |     ---- ^^^^^^^^^^ the trait `Trait` is not implemented for `Pin<Box<dyn Future<Output = ()> + Send>>`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Trait` is implemented for `A`
+note: required by a bound in `test`
+  --> tests/ui/sync.rs:16:31
+   |
+16 |     fn test<T>(a: T) where T: Trait + Send + Sync  {}
+   |                               ^^^^^ required by this bound in `test`
+
+error[E0277]: `dyn Future<Output = ()> + Send` cannot be shared between threads safely
+  --> tests/ui/sync.rs:17:10
+   |
+17 |     test(A.method());
+   |     ---- ^^^^^^^^^^ `dyn Future<Output = ()> + Send` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Sync` is not implemented for `dyn Future<Output = ()> + Send`
+   = note: required for `Unique<dyn Future<Output = ()> + Send>` to implement `Sync`
+   = note: required because it appears within the type `Box<dyn Future<Output = ()> + Send>`
+   = note: required because it appears within the type `Pin<Box<dyn Future<Output = ()> + Send>>`
+note: required by a bound in `test`
+  --> tests/ui/sync.rs:16:46
+   |
+16 |     fn test<T>(a: T) where T: Trait + Send + Sync  {}
+   |                                              ^^^^ required by this bound in `test`


### PR DESCRIPTION
Hey,

I ran into the issue where some of my futures must be `Send + Sync`, browsing the issue tracker I've found https://github.com/dtolnay/async-trait/issues/77 too.

Is this something you would be willing to accept contribution to? If that is the case, I'd love to discuss the best approach.

This PR is a draft/proposal on how we can solve this issue. I don´t particularly like my implementation tho, but once we agree on an API I can polish the implementation.

---

The API I am using here is as follows:

```rust
#[async_trait(+Sync)]
pub trait Trait {
    async fn f(&self);
}

struct A;

#[async_trait]
impl Trait for A {
    async fn f(&self) {}
}
``` 

---

Thanks