### PR TITLE
Delete replacement of elided lifetimes in impl heading

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -80,13 +80,6 @@ pub fn expand(input: &mut Item, is_local: bool) {
             }
         }
         Item::Impl(input) => {
-            let mut lifetimes = CollectLifetimes::new("'impl");
-            lifetimes.visit_type_mut(&mut *input.self_ty);
-            lifetimes.visit_path_mut(&mut input.trait_.as_mut().unwrap().1);
-            let params = &input.generics.params;
-            let elided = lifetimes.elided;
-            input.generics.params = parse_quote!(#(#elided,)* #params);
-
             let mut associated_type_impl_traits = Set::new();
             for inner in &input.items {
                 if let ImplItem::Type(assoc) = inner {
@@ -167,7 +160,7 @@ fn transform_sig(
         ReturnType::Type(arrow, ret) => (*arrow, quote!(#ret)),
     };
 
-    let mut lifetimes = CollectLifetimes::new("'life");
+    let mut lifetimes = CollectLifetimes::new();
     for arg in sig.inputs.iter_mut() {
         match arg {
             FnArg::Receiver(arg) => lifetimes.visit_receiver_mut(arg),

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -9,15 +9,13 @@ use syn::{
 pub struct CollectLifetimes {
     pub elided: Vec<Lifetime>,
     pub explicit: Vec<Lifetime>,
-    pub name: &'static str,
 }
 
 impl CollectLifetimes {
-    pub fn new(name: &'static str) -> Self {
+    pub fn new() -> Self {
         CollectLifetimes {
             elided: Vec::new(),
             explicit: Vec::new(),
-            name,
         }
     }
 
@@ -37,7 +35,7 @@ impl CollectLifetimes {
     }
 
     fn next_lifetime(&mut self, span: Span) -> Lifetime {
-        let name = format!("{}{}", self.name, self.elided.len());
+        let name = format!("'life{}", self.elided.len());
         let life = Lifetime::new(&name, span);
         self.elided.push(life.clone());
         life

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1585,3 +1585,22 @@ pub mod issue236 {
         }
     }
 }
+
+// https://github.com/dtolnay/async-trait/issues/238
+pub mod issue238 {
+    #![deny(single_use_lifetimes)]
+
+    use async_trait::async_trait;
+
+    #[async_trait]
+    pub trait Trait {
+        async fn f();
+    }
+
+    pub struct Struct;
+
+    #[async_trait]
+    impl Trait for &Struct {
+        async fn f() {}
+    }
+}


### PR DESCRIPTION
This reverts PR #107. The code from that PR is no longer necessary for 2 reasons.

1. As of https://github.com/rust-lang/rust/pull/85499 in Rust 1.56.0, the problem described in #106 involving `FnOnce(&Self::ThreadPool)` vs `FnOnce(&<&P as ProcessPool>::ThreadPool)` does not occur. These two trait bounds mean the same thing to sufficiently new versions of Rust.

2. As of #143 in async-trait 0.1.43 we no longer replace `FnOnce(&Self::ThreadPool)` to `FnOnce(&<&P as ProcessPool>::ThreadPool)` in generated code, so even with old rustc, the old problem does not occur.

Fixes #238.