### PR TITLE
Re-enable tracing integration test under Miri

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ quote = "1.0.29"
 syn = { version = "2.0.23", features = ["full", "visit-mut"] }
 
 [dev-dependencies]
-futures = "0.3.28"
+futures = "0.3.30"
 rustversion = "1.0.13"
-tracing = "0.1.37"
-tracing-attributes = "0.1.26"
+tracing = "0.1.40"
+tracing-attributes = "0.1.27"
 trybuild = { version = "1.0.81", features = ["diff"] }
 
 [package.metadata.docs.rs]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -620,7 +620,6 @@ pub mod issue45 {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // https://github.com/matklad/once_cell/pull/185
     fn tracing() {
         // Create the future outside of the subscriber, as no call to tracing
         // should be made until the future is polled.


### PR DESCRIPTION
The pull request that this links to was landed and release in once_cell 1.13.1.