### PR TITLE
Ignore unused_qualifications rustc lint in generated code

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -125,6 +125,7 @@ pub fn expand(input: &mut Item, is_local: bool) {
 fn lint_suppress_with_body() -> Attribute {
     parse_quote! {
         #[allow(
+            unused_qualifications,
             clippy::async_yields_async,
             clippy::diverging_sub_expression,
             clippy::let_unit_value,
@@ -140,6 +141,7 @@ fn lint_suppress_with_body() -> Attribute {
 fn lint_suppress_without_body() -> Attribute {
     parse_quote! {
         #[allow(
+            unused_qualifications,
             clippy::type_complexity,
             clippy::type_repetition_in_bounds
         )]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,7 +2,7 @@
     async_trait_nightly_testing,
     feature(impl_trait_in_assoc_type, min_specialization)
 )]
-#![deny(rust_2021_compatibility)]
+#![deny(rust_2021_compatibility, unused_qualifications)]
 #![allow(
     clippy::incompatible_msrv, // https://github.com/rust-lang/rust-clippy/issues/12257
     clippy::let_underscore_untyped,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1384,6 +1384,7 @@ pub mod issue169 {
     use async_trait::async_trait;
 
     #[async_trait]
+    #[allow(unused_qualifications)]
     pub trait Trait: ::core::marker::Sync {
         async fn f(&self) {}
     }


### PR DESCRIPTION
Fixes #259. The new lints in nightly-2024-03-05 are resulting from https://github.com/rust-lang/rust/pull/121528.