### PR TITLE
Fix unreachable code warning for functions that return `!`

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -409,6 +409,7 @@ fn transform_block(context: Context, sig: &mut Signature, block: &mut Block) {
             } else {
                 quote! {
                     if let ::core::option::Option::Some(__ret) = ::core::option::Option::None::<#ret> {
+                        #[allow(unreachable_code)]
                         return __ret;
                     }
                     #(#decls)*

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(
     async_trait_nightly_testing,
-    feature(impl_trait_in_assoc_type, min_specialization)
+    feature(impl_trait_in_assoc_type, min_specialization, never_type)
 )]
 #![deny(rust_2021_compatibility, unused_qualifications)]
 #![allow(
@@ -248,6 +248,25 @@ pub async fn test_unimplemented() {
     }
 
     impl Trait for () {}
+
+    let _ = <() as Trait>::f;
+}
+
+#[cfg(async_trait_nightly_testing)]
+pub async fn test_divering_function() {
+    #[async_trait]
+    pub trait Trait {
+        async fn f() -> !;
+    }
+
+    #[async_trait]
+    impl Trait for () {
+        async fn f() -> ! {
+            loop {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+        }
+    }
 
     let _ = <() as Trait>::f;
 }


### PR DESCRIPTION
The generated code for function bodies produces an `unreachable_code` warning if the function has a `!` return type.

The offending bit is:
```rust
if let Some(__ret) == None::<!> {
  // unreachable
}
```

This PR fixes the warning by simply adding `#[allow(unreachable_code)]` to the return statement. It also adds a test for it.

This problem can only be triggered on nightly with the `never_type` feature enabled, but it is easy to fix here.