### PR TITLE
Former where_clauses_object_safety lint is now hard error

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1380,7 +1380,6 @@ pub mod issue161 {
 }
 
 // https://github.com/dtolnay/async-trait/issues/169
-#[deny(where_clauses_object_safety)]
 pub mod issue169 {
     use async_trait::async_trait;
 


### PR DESCRIPTION
Since nightly-2024-06-05 (https://github.com/rust-lang/rust/pull/125380).

```console
warning: unknown lint: `where_clauses_object_safety`
    --> tests/test.rs:1383:8
     |
1383 | #[deny(where_clauses_object_safety)]
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `#[warn(unknown_lints)]` on by default
```