### PR TITLE
syn: remove derive feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.74"
 quote = "1.0.35"
-syn = { version = "2.0.46", features = ["full", "visit-mut"] }
+syn = { version = "2.0.46", default-features = false, features = ["full", "visit-mut", "parsing", "printing", "proc-macro", "clone-impls"] }
 
 [dev-dependencies]
 futures = "0.3.30"


### PR DESCRIPTION
Effectively unsets `derive` feature (and `default`, obviously), removing unused feature.