### PR TITLE
Ignore nightly's new elided_named_lifetimes lint in generated code

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -125,6 +125,7 @@ pub fn expand(input: &mut Item, is_local: bool) {
 fn lint_suppress_with_body() -> Attribute {
     parse_quote! {
         #[allow(
+            elided_named_lifetimes,
             clippy::async_yields_async,
             clippy::diverging_sub_expression,
             clippy::let_unit_value,
@@ -140,6 +141,7 @@ fn lint_suppress_with_body() -> Attribute {
 fn lint_suppress_without_body() -> Attribute {
     parse_quote! {
         #[allow(
+            elided_named_lifetimes,
             clippy::type_complexity,
             clippy::type_repetition_in_bounds
         )]


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/129207 added this lint:

```console
warning: elided lifetime has a name
    --> tests/test.rs:1118:30
     |
1118 |         async fn f(&self) -> &str
     |                    -         ^ this elided lifetime gets resolved as `'life0`
     |                    |
     |                    lifetime `'life0` declared here
     |
     = note: `#[warn(elided_named_lifetimes)]` on by default
```

For #\[async_trait\] this is not useful because the macro needs to give names to some lifetimes which are not named in the user's code.