### PR TITLE
Ignore needless_arbitrary_self_type clippy lint in generated code

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -129,6 +129,7 @@ fn lint_suppress_with_body() -> Attribute {
             clippy::async_yields_async,
             clippy::diverging_sub_expression,
             clippy::let_unit_value,
+            clippy::needless_arbitrary_self_type,
             clippy::no_effect_underscore_binding,
             clippy::shadow_same,
             clippy::type_complexity,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1641,3 +1641,22 @@ pub mod issue266 {
         }
     }
 }
+
+// https://github.com/dtolnay/async-trait/issues/277
+pub mod issue277 {
+    use async_trait::async_trait;
+
+    #[async_trait]
+    pub trait Trait {
+        async fn f(&self);
+    }
+
+    #[async_trait]
+    impl Trait for () {
+        async fn f(mut self: &Self) {
+            g(&mut self);
+        }
+    }
+
+    fn g(_: &mut &()) {}
+}


### PR DESCRIPTION
Closes #277.