### PR TITLE
Omit `Self: 'async_trait` bound in impl when not needed by signature

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -99,7 +99,7 @@ pub fn expand(input: &mut Item, is_local: bool) {
                     ImplItem::Fn(method) if method.sig.asyncness.is_some() => {
                         let sig = &mut method.sig;
                         let block = &mut method.block;
-                        let has_self = has_self_in_sig(sig) || has_self_in_block(block);
+                        let has_self = has_self_in_sig(sig);
                         transform_block(context, sig, block);
                         transform_sig(context, sig, has_self, false, is_local);
                         method.attrs.push(lint_suppress_with_body());

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1683,3 +1683,23 @@ pub mod issue281 {
         }
     }
 }
+
+pub mod issue283 {
+    use async_trait::async_trait;
+
+    #[async_trait]
+    pub trait Trait {
+        async fn a();
+    }
+
+    pub trait Bound {
+        fn b();
+    }
+
+    #[async_trait]
+    impl<T: Bound> Trait for T {
+        async fn a() {
+            Self::b();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #283.