### PR TITLE
Slightly improve usage of spans in `quote_spanned`

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -404,18 +404,18 @@ fn transform_block(context: Context, sig: &mut Signature, block: &mut Block) {
         ReplaceSelf.visit_block_mut(block);
     }
 
-    let stmts = &block.stmts;
     let let_ret = match &mut sig.output {
-        ReturnType::Default => quote_spanned! {block.brace_token.span=>
+        ReturnType::Default => quote! {
             #(#decls)*
-            let () = { #(#stmts)* };
+            let _: () = #block;
         },
         ReturnType::Type(_, ret) => {
             if contains_associated_type_impl_trait(context, ret) {
                 if decls.is_empty() {
+                    let stmts = &block.stmts;
                     quote!(#(#stmts)*)
                 } else {
-                    quote!(#(#decls)* { #(#stmts)* })
+                    quote!(#(#decls)* #block)
                 }
             } else {
                 let mut ret = ret.clone();
@@ -426,14 +426,14 @@ fn transform_block(context: Context, sig: &mut Signature, block: &mut Block) {
                         return __ret;
                     }
                     #(#decls)*
-                    let __ret: #ret = { #(#stmts)* };
+                    let __ret: #ret = #block;
                     #[allow(unreachable_code)]
                     __ret
                 }
             }
         }
     };
-    let box_pin = quote_spanned!(block.brace_token.span=>
+    let box_pin = quote_spanned!(sig.asyncness.unwrap().span =>
         Box::pin(async move { #let_ret })
     );
     block.stmts = parse_quote!(#box_pin);

--- a/tests/ui/consider-restricting.stderr
+++ b/tests/ui/consider-restricting.stderr
@@ -1,32 +1,32 @@
 error: future cannot be sent between threads safely
-  --> tests/ui/consider-restricting.rs:16:50
+  --> tests/ui/consider-restricting.rs:16:5
    |
 16 |     async fn publish<T: IntoUrl>(&self, _url: T) {}
-   |                                                  ^^ future created by async block is not `Send`
+   |     ^^^^^ future created by async block is not `Send`
    |
 note: captured value is not `Send`
   --> tests/ui/consider-restricting.rs:16:41
    |
 16 |     async fn publish<T: IntoUrl>(&self, _url: T) {}
    |                                         ^^^^ has type `T` which is not `Send`
-   = note: required for the cast from `Pin<Box<{async block@$DIR/tests/ui/consider-restricting.rs:16:50: 16:52}>>` to `Pin<Box<dyn Future<Output = ()> + Send>>`
+   = note: required for the cast from `Pin<Box<{async block@$DIR/tests/ui/consider-restricting.rs:16:5: 16:10}>>` to `Pin<Box<dyn Future<Output = ()> + Send>>`
 help: consider further restricting type parameter `T` with trait `Send`
    |
 16 |     async fn publish<T: IntoUrl + std::marker::Send>(&self, _url: T) {}
    |                                 +++++++++++++++++++
 
 error: future cannot be sent between threads safely
-  --> tests/ui/consider-restricting.rs:23:41
+  --> tests/ui/consider-restricting.rs:23:5
    |
 23 |     async fn publish<T>(&self, _url: T) {}
-   |                                         ^^ future created by async block is not `Send`
+   |     ^^^^^ future created by async block is not `Send`
    |
 note: captured value is not `Send`
   --> tests/ui/consider-restricting.rs:23:32
    |
 23 |     async fn publish<T>(&self, _url: T) {}
    |                                ^^^^ has type `T` which is not `Send`
-   = note: required for the cast from `Pin<Box<{async block@$DIR/tests/ui/consider-restricting.rs:23:41: 23:43}>>` to `Pin<Box<dyn Future<Output = ()> + Send>>`
+   = note: required for the cast from `Pin<Box<{async block@$DIR/tests/ui/consider-restricting.rs:23:5: 23:10}>>` to `Pin<Box<dyn Future<Output = ()> + Send>>`
 help: consider further restricting type parameter `T` with trait `Send`
    |
 23 |     async fn publish<T + std::marker::Send>(&self, _url: T) {}

--- a/tests/ui/send-not-implemented.stderr
+++ b/tests/ui/send-not-implemented.stderr
@@ -1,15 +1,10 @@
 error: future cannot be sent between threads safely
-  --> tests/ui/send-not-implemented.rs:8:26
+  --> tests/ui/send-not-implemented.rs:8:5
    |
- 8 |       async fn test(&self) {
-   |  __________________________^
- 9 | |         let mutex = Mutex::new(());
-10 | |         let _guard = mutex.lock().unwrap();
-11 | |         f().await;
-12 | |     }
-   | |_____^ future created by async block is not `Send`
+ 8 |     async fn test(&self) {
+   |     ^^^^^ future created by async block is not `Send`
    |
-   = help: within `{async block@$DIR/tests/ui/send-not-implemented.rs:8:26: 12:6}`, the trait `Send` is not implemented for `std::sync::MutexGuard<'_, ()>`
+   = help: within `{async block@$DIR/tests/ui/send-not-implemented.rs:8:5: 8:10}`, the trait `Send` is not implemented for `std::sync::MutexGuard<'_, ()>`
 note: future is not `Send` as this value is used across an await
   --> tests/ui/send-not-implemented.rs:11:13
    |
@@ -17,21 +12,15 @@ note: future is not `Send` as this value is used across an await
    |             ------ has type `std::sync::MutexGuard<'_, ()>` which is not `Send`
 11 |         f().await;
    |             ^^^^^ await occurs here, with `_guard` maybe used later
-   = note: required for the cast from `Pin<Box<{async block@$DIR/tests/ui/send-not-implemented.rs:8:26: 12:6}>>` to `Pin<Box<dyn Future<Output = ()> + Send>>`
+   = note: required for the cast from `Pin<Box<{async block@$DIR/tests/ui/send-not-implemented.rs:8:5: 8:10}>>` to `Pin<Box<dyn Future<Output = ()> + Send>>`
 
 error: future cannot be sent between threads safely
-  --> tests/ui/send-not-implemented.rs:14:38
+  --> tests/ui/send-not-implemented.rs:14:5
    |
-14 |       async fn test_ret(&self) -> bool {
-   |  ______________________________________^
-15 | |         let mutex = Mutex::new(());
-16 | |         let _guard = mutex.lock().unwrap();
-17 | |         f().await;
-18 | |         true
-19 | |     }
-   | |_____^ future created by async block is not `Send`
+14 |     async fn test_ret(&self) -> bool {
+   |     ^^^^^ future created by async block is not `Send`
    |
-   = help: within `{async block@$DIR/tests/ui/send-not-implemented.rs:14:38: 19:6}`, the trait `Send` is not implemented for `std::sync::MutexGuard<'_, ()>`
+   = help: within `{async block@$DIR/tests/ui/send-not-implemented.rs:14:5: 14:10}`, the trait `Send` is not implemented for `std::sync::MutexGuard<'_, ()>`
 note: future is not `Send` as this value is used across an await
   --> tests/ui/send-not-implemented.rs:17:13
    |
@@ -39,4 +28,4 @@ note: future is not `Send` as this value is used across an await
    |             ------ has type `std::sync::MutexGuard<'_, ()>` which is not `Send`
 17 |         f().await;
    |             ^^^^^ await occurs here, with `_guard` maybe used later
-   = note: required for the cast from `Pin<Box<{async block@$DIR/tests/ui/send-not-implemented.rs:14:38: 19:6}>>` to `Pin<Box<dyn Future<Output = bool> + Send>>`
+   = note: required for the cast from `Pin<Box<{async block@$DIR/tests/ui/send-not-implemented.rs:14:5: 14:10}>>` to `Pin<Box<dyn Future<Output = bool> + Send>>`

--- a/tests/ui/type-mismatch.rs
+++ b/tests/ui/type-mismatch.rs
@@ -1,0 +1,21 @@
+use async_trait::async_trait;
+
+#[async_trait]
+trait Interface {
+    async fn f(&self);
+    async fn g(&self) -> ();
+}
+
+struct Thing;
+
+#[async_trait]
+impl Interface for Thing {
+    async fn f(&self) {
+        0
+    }
+    async fn g(&self) {
+        0
+    }
+}
+
+fn main() {}

--- a/tests/ui/type-mismatch.stderr
+++ b/tests/ui/type-mismatch.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+  --> tests/ui/type-mismatch.rs:13:23
+   |
+13 |       async fn f(&self) {
+   |  _______________________^
+14 | |         0
+15 | |     }
+   | |_____^ expected integer, found `()`
+
+error[E0308]: mismatched types
+  --> tests/ui/type-mismatch.rs:16:23
+   |
+16 |       async fn g(&self) {
+   |  _______________________^
+17 | |         0
+18 | |     }
+   | |_____^ expected integer, found `()`

--- a/tests/ui/type-mismatch.stderr
+++ b/tests/ui/type-mismatch.stderr
@@ -1,17 +1,11 @@
 error[E0308]: mismatched types
-  --> tests/ui/type-mismatch.rs:13:23
+  --> tests/ui/type-mismatch.rs:14:9
    |
-13 |       async fn f(&self) {
-   |  _______________________^
-14 | |         0
-15 | |     }
-   | |_____^ expected integer, found `()`
+14 |         0
+   |         ^ expected `()`, found integer
 
 error[E0308]: mismatched types
-  --> tests/ui/type-mismatch.rs:16:23
+  --> tests/ui/type-mismatch.rs:17:9
    |
-16 |       async fn g(&self) {
-   |  _______________________^
-17 | |         0
-18 | |     }
-   | |_____^ expected integer, found `()`
+17 |         0
+   |         ^ expected `()`, found integer


### PR DESCRIPTION
The use of the whole body span unfortunately trips up rust-analyzer wrt to certain IDE features and we cannot accommodate for that without regressing other functionality with macros that are desired, https://github.com/rust-lang/rust-analyzer/issues/20441.

This PR attempts to change the use of the problematic spans without regressing diagnostics (subjective, as they do change).