### PR TITLE
use alloc::boxed::Box instead of the builtin Box

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.90"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 categories = ["asynchronous", "no-std"]
 description = "Type erasure for async trait methods"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ rust-version = "1.71"
 [lib]
 proc-macro = true
 
+[features]
+alloc = []
+
 [dependencies]
 proc-macro2 = "1.0.74"
 quote = "1.0.35"

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ If you're using `async-trait` from a `no_std` environment with `alloc`, enable
 
 ```toml
 [dependencies]
-async-trait = { version = "0.1.89", features = ["alloc"] }
+async-trait = { version = "0.1.90", features = ["alloc"] }
 ```
 
 <br>

--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ macro as `#[async_trait(?Send)]` on both the trait and the impl blocks.
 
 <br>
 
+## `no_std` usage
+
+If you're using `async-trait` from a `no_std` environment with `alloc`, enable
+`async-trait`'s `alloc` feature.
+
+```toml
+[dependencies]
+async-trait = { version = "0.1.89", features = ["alloc"] }
+```
+
+<br>
+
 ## Elided lifetimes
 
 Be aware that async fn syntax does not allow lifetime elision outside of `&` and

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -322,7 +322,7 @@ fn transform_sig(
         quote!(::core::marker::Send + 'async_trait)
     };
     sig.output = parse_quote! {
-        #ret_arrow ::core::pin::Pin<Box<
+        #ret_arrow ::core::pin::Pin<::alloc::boxed::Box<
             dyn ::core::future::Future<Output = #ret> + #bounds
         >>
     };
@@ -434,7 +434,7 @@ fn transform_block(context: Context, sig: &mut Signature, block: &mut Block) {
         }
     };
     let box_pin = quote_spanned!(sig.asyncness.unwrap().span=>
-        Box::pin(async move { #let_ret })
+        ::alloc::boxed::Box::pin(async move { #let_ret })
     );
     block.stmts = parse_quote!(#box_pin);
 }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -321,11 +321,23 @@ fn transform_sig(
     } else {
         quote!(::core::marker::Send + 'async_trait)
     };
-    sig.output = parse_quote! {
-        #ret_arrow ::core::pin::Pin<::alloc::boxed::Box<
-            dyn ::core::future::Future<Output = #ret> + #bounds
-        >>
-    };
+    #[cfg(feature = "alloc")]
+    {
+        sig.output = parse_quote! {
+            #ret_arrow ::core::pin::Pin<::alloc::boxed::Box<
+                dyn ::core::future::Future<Output = #ret> + #bounds
+            >>
+        };
+    }
+
+    #[cfg(not(feature = "alloc"))]
+    {
+        sig.output = parse_quote! {
+            #ret_arrow ::core::pin::Pin<Box<
+                dyn ::core::future::Future<Output = #ret> + #bounds
+            >>
+        };
+    }
 }
 
 // Input:
@@ -433,8 +445,14 @@ fn transform_block(context: Context, sig: &mut Signature, block: &mut Block) {
             }
         }
     };
+    #[cfg(feature = "alloc")]
     let box_pin = quote_spanned!(sig.asyncness.unwrap().span=>
         ::alloc::boxed::Box::pin(async move { #let_ret })
+    );
+
+    #[cfg(not(feature = "alloc"))]
+    let box_pin = quote_spanned!(sig.asyncness.unwrap().span=>
+        Box::pin(async move { #let_ret })
     );
     block.stmts = parse_quote!(#box_pin);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! async-trait = { version = "0.1.89", features = ["alloc"] }
+//! async-trait = { version = "0.1.90", features = ["alloc"] }
 //! ```
 //!
 //! <br>
@@ -226,7 +226,7 @@
 //! }
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/async-trait/0.1.89")]
+#![doc(html_root_url = "https://docs.rs/async-trait/0.1.90")]
 #![allow(
     clippy::default_trait_access,
     clippy::doc_markdown,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,18 @@
 //!
 //! <br>
 //!
+//! # `no_std` usage
+//!
+//! If you're using `async-trait` from a `no_std` environment with `alloc`,
+//! enable `async-trait`'s `alloc` feature.
+//!
+//! ```toml
+//! [dependencies]
+//! async-trait = { version = "0.1.89", features = ["alloc"] }
+//! ```
+//!
+//! <br>
+//!
 //! # Elided lifetimes
 //!
 //! Be aware that async fn syntax does not allow lifetime elision outside of `&`

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -1,0 +1,67 @@
+#![cfg(feature = "alloc")]
+#![no_std]
+
+extern crate alloc;
+extern crate std;
+
+use alloc::boxed::Box;
+use async_trait::async_trait;
+
+mod executor;
+
+struct Struct;
+
+#[async_trait]
+trait Trait {
+    type Assoc;
+
+    async fn selfref(&self) {}
+
+    async fn required() -> Self::Assoc;
+
+    async fn generic_type_param<T: Send>(x: Box<T>) -> T {
+        *x
+    }
+}
+
+#[async_trait]
+impl Trait for Struct {
+    type Assoc = ();
+
+    async fn selfref(&self) {}
+
+    async fn required() -> Self::Assoc {}
+
+    async fn generic_type_param<T: Send>(x: Box<T>) -> T {
+        *x
+    }
+}
+
+#[test]
+fn test_no_std_alloc_trait_methods() {
+    executor::block_on_simple(async {
+        let s = Struct;
+        s.selfref().await;
+
+        Struct::required().await;
+        Struct::generic_type_param(Box::new("")).await;
+    });
+}
+
+#[test]
+fn test_no_std_alloc_dyn_compatible() {
+    #[async_trait]
+    trait DynCompatible {
+        async fn f(&self);
+    }
+
+    #[async_trait]
+    impl DynCompatible for Struct {
+        async fn f(&self) {}
+    }
+
+    executor::block_on_simple(async {
+        let object = &Struct as &dyn DynCompatible;
+        object.f().await;
+    });
+}

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -4,7 +4,6 @@
 extern crate alloc;
 extern crate std;
 
-use alloc::boxed::Box;
 use async_trait::async_trait;
 
 mod executor;
@@ -18,10 +17,6 @@ trait Trait {
     async fn selfref(&self) {}
 
     async fn required() -> Self::Assoc;
-
-    async fn generic_type_param<T: Send>(x: Box<T>) -> T {
-        *x
-    }
 }
 
 #[async_trait]
@@ -31,10 +26,6 @@ impl Trait for Struct {
     async fn selfref(&self) {}
 
     async fn required() -> Self::Assoc {}
-
-    async fn generic_type_param<T: Send>(x: Box<T>) -> T {
-        *x
-    }
 }
 
 #[test]
@@ -44,7 +35,6 @@ fn test_no_std_alloc_trait_methods() {
         s.selfref().await;
 
         Struct::required().await;
-        Struct::generic_type_param(Box::new("")).await;
     });
 }
 


### PR DESCRIPTION
uses `alloc::boxed::Box` instead of `Box`
this ensures that this crate works on `no_std` environment

fixes #295 